### PR TITLE
one-line-scan: initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,1 @@
-## One Line Scan
-
-With this tool, projects can be compiled easily for fuzzing with AFL or for static code analysis with tools like CBMC.One-line-scan hooks into the compilation process and wraps calls to the compiler with other compilers.Besides the compilation wrappers, one-line-scan ships with basic analysis jobs, that allow to analyze a project right after compilation with the following tools:AFL, cppcheck, CBMC, PVS Studio, Fortify.
-
-## License
-
-This library is licensed under the Apache 2.0 License. 
+configuration/doc/README.md

--- a/configuration/backends/AFL/AFL-hook-install.sh
+++ b/configuration/backends/AFL/AFL-hook-install.sh
@@ -1,0 +1,93 @@
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# This file is meant to be sourced by the setup script that installs all
+# selected wrapper hooks. Hence, it contains variables that are not defined in
+# this script.
+
+# To be able to compile for fuzzing with AFL, inject wrappers
+inject_afl()
+{
+  # use source dir to be able to copy the correct wrapper script
+  local -r HOOK_SRC_DIR="$( dirname "${BASH_SOURCE[0]}" )"
+
+  # check whether we can find the wrapper script
+  if [ ! -f $HOOK_SRC_DIR/afl-wrapper.sh ]
+  then
+    echo "error: cannot find wrapper script $HOOK_SRC_DIR/afl-wrapper.sh"
+    return 1
+  fi
+
+  # we will place the AFL wrapper here
+  mkdir -p "$GOTO_GCC_WRAPPER_INSTALL_DIR/AFL"
+  # we will point all calls to relevant compilers to the same wrapper
+  local TARGET_GCC="$GOTO_GCC_WRAPPER_INSTALL_DIR/AFL/gcc"
+  cp "$HOOK_SRC_DIR"/afl-wrapper.sh "$TARGET_GCC"
+
+  # we did not find afl-gcc on the path, so we cannot continue
+  if ! which afl-gcc > /dev/null 2>&1
+  then
+    echo "error: cannot inject AFL compilers, as afl-gcc cannot be found"
+    return 1
+  fi
+
+  # extract the AFL directory from the afl-gcc binary location, set in environment
+  local AFL_GCC_LOCATION=$(which afl-gcc 2> /dev/null)
+
+  # add extra arguments to wrapper script
+  if [ -n "$GCC_WRAPPER_EXTRAARGUMENTS" ]
+  then
+    perl -p -i -e "s:^GCCEXTRAARGUMENTS=:GCCEXTRAARGUMENTS=\"$GCC_WRAPPER_EXTRAARGUMENTS\":" "$TARGET_GCC"
+  fi
+
+  # check whether AFL is set up correctly (i.e. a link of as is located in the
+  # directory that is pointed to by AFL_PATH. Without that link, compilation
+  # will fail
+  if [ ! -x "$(dirname "$AFL_GCC_LOCATION")/as" ]
+  then
+    echo "error: cannot find \"as\" binary in AFL PATH, i.e. in $(dirname "$AFL_GCC_LOCATION")"
+    return 1
+  fi
+
+  export AFL_PATH=$(dirname "$AFL_GCC_LOCATION")
+  perl -p -i -e "s:NATIVE_AFL_PATH=:NATIVE_AFL_PATH=$(dirname "$AFL_GCC_LOCATION"):" "$TARGET_GCC"
+  # tell the wrapper about the location of AFL
+  perl -p -i -e "s:NATIVE_GCC=/bin/false:NATIVE_GCC=$GOTO_GCC_NATIVE_COMPILER:" "$TARGET_GCC"
+
+  # activate all other AFL binaries
+#  if which afl-as > /dev/null 2>&1
+#  then
+#    perl -p -i -e "s:NATIVE_AS=/bin/false:NATIVE_AS=$(which afl-as 2> /dev/null):" "$TARGET_GCC"
+#    cp "$GOTO_GCC_WRAPPER_INSTALL_DIR/AFL/gcc" "$GOTO_GCC_WRAPPER_INSTALL_DIR/AFL/as"
+#    cp "$GOTO_GCC_WRAPPER_INSTALL_DIR/AFL/gcc" "$GOTO_GCC_WRAPPER_INSTALL_DIR/AFL/afl-as"
+#  else
+#    echo "error: cannot find afl-as"
+#    return 1
+#  fi
+
+  # it is not too bad, if we cannot find the other compilers, so we do not complain in these cases
+  perl -p -i -e "s:NATIVE_CLANG=/bin/false:NATIVE_CLANG=$(find_native clang):" "$TARGET_GCC"
+  perl -p -i -e "s:NATIVE_GPP=/bin/false:NATIVE_GPP=$(find_native g++):" "$TARGET_GCC"
+  perl -p -i -e "s:NATIVE_CLANGPP=/bin/false:NATIVE_CLANGPP=$(find_native clang++):" "$TARGET_GCC"
+
+  for t in clang afl-clang g++ afl-g++ clang++ afl-clang++
+  do
+    cp "$TARGET_GCC" "$GOTO_GCC_WRAPPER_INSTALL_DIR/AFL/$t"
+  done
+
+  # after using all previous tool locations to setup the wrapper script,
+  # activate the wrapper script
+  export PATH="$GOTO_GCC_WRAPPER_INSTALL_DIR/AFL":$PATH
+  return 0
+}
+

--- a/configuration/backends/AFL/afl-wrapper.sh
+++ b/configuration/backends/AFL/afl-wrapper.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+#
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# control whether gcc has been called by afl, or some other tool
+
+#################### DO NOT MODIFY ##################
+
+# by default, all supported tools have not been found.
+NATIVE_GCC=/bin/false
+NATIVE_GPP=/bin/false
+NATIVE_CLANG=/bin/false
+NATIVE_CLANGPP=/bin/false
+NATIVE_AS=/bin/false
+
+# path to the actual AFL binaries
+NATIVE_AFL_PATH=
+
+# load the library
+SCRIPT=$(readlink -e "$0")
+source $(dirname $SCRIPT)/../ols-library.sh || exit 1
+
+# arguments that should be added to the compiler (DO NOT TOUCH)
+GCCEXTRAARGUMENTS=
+
+# base file to check whether the current process has been called by the wrapper
+WRAPPERPIDFILE=/tmp/AFL-wrapper-pid
+
+# if log file is not empty, store logging
+LOG=log
+
+#
+# start of the script
+#
+# redirect stdin to another file descriptor (here we picked 4), and close stdin afterwards
+# use this to pass stdin to the actual compiler call, and not to tools used before
+REDIRECT_STDIN=0
+if [ -t 0 ]
+then
+  REDIRECT_STDIN=1
+  exec 4<&0
+  exec 0<&-
+fi
+
+# use the binary name
+binary_name=$(basename $0)
+
+# check whether some parent is the wrapper already
+parent_result=0
+called_by_wrapper $$ || parent_result=$?
+
+logwrapper AFL-GCC "called $binary_name, parent is AFL wrapper: $parent_result"
+
+# if wrapper is already active somewhere in the calling tree, call original program
+if [ "$parent_result" == "1" ]
+then
+  case "$binary_name" in
+    "gcc"|"afl-gcc")
+      [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+      if [ "$NATIVE_GCC" = "/bin/true" ]
+      then
+        $(next_in_path gcc AFL) "$@"
+        exit $?
+      else
+        "$NATIVE_GCC" "$@" $GCCEXTRAARGUMENTS
+        exit $?
+      fi
+      ;;
+    "g++"|"afl-g++")
+      [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+      if [ "$NATIVE_GPP" = "/bin/true" ]
+      then
+        $(next_in_path g++ AFL) "$@"
+        exit $?
+      else
+        "$NATIVE_GPP" "$@" $GCCEXTRAARGUMENTS
+        exit $?
+      fi
+      ;;
+    "clang"|"afl-clang")
+      [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+      if [ "$NATIVE_CLANG" = "/bin/true" ]
+      then
+        $(next_in_path clang AFL) "$@"
+        exit $?
+      else
+        "$NATIVE_CLANG" "$@" $GCCEXTRAARGUMENTS
+        exit $?
+      fi
+      ;;
+    "clang++"|"afl-clang++")
+      [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+      if [ "$NATIVE_CLANGPP" = "/bin/true" ]
+      then
+        $(next_in_path clang++ AFL) "$@"
+        exit $?
+      else
+        "$NATIVE_CLANGPP" "$@" $GCCEXTRAARGUMENTS
+        exit $?
+      fi
+      ;;
+    "as"|"afl-as")
+      [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+      if [ "$NATIVE_AS" = "/bin/true" ]
+      then
+        $(next_in_path as AFL) "$@"
+        exit $?
+      else
+        "$NATIVE_AS" "$@" $GCCEXTRAARGUMENTS
+        exit $?
+      fi
+      ;;
+    *)
+      echo "error: AFL wrapper has been called with an unknown tool name: $binary_name" 2>&1
+      exit 1
+      ;;
+  esac
+fi
+
+# free the lock and the parent pid file in case something gets wrong
+trap exit_handler EXIT
+
+# tell that we are using the wrapper now with the current PID
+touch "$WRAPPERPIDFILE$$"
+
+# use the actual AFL binary
+case "$binary_name" in
+  "gcc" | "g++" | "clang" | "clang++" | "as" )
+    logwrapper AFL-GCC "call actual tool:$NATIVE_AFL_PATH/afl-$binary_name $@ $GCCEXTRAARGUMENTS"
+    [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+    "$NATIVE_AFL_PATH"/afl-"$binary_name" "$@" $GCCEXTRAARGUMENTS
+    exit $?
+    ;;
+  "afl-gcc" | "afl-g++" | "afl-clang" | "afl-clang++" | "afl-as" )
+    logwrapper AFL-GCC "call actual tool:$NATIVE_AFL_PATH/$binary_name $@ $GCCEXTRAARGUMENTS"
+    [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+    "$NATIVE_AFL_PATH"/"$binary_name" "$@" $GCCEXTRAARGUMENTS
+    exit $?
+    ;;
+  *)
+    echo "error: AFL wrapper has been called with an unknown tool name: $binary_name" 2>&1
+    exit 1
+    ;;
+esac
+
+# make sure we do not enter the goto-gcc path again
+# cleanup is performed by exit handler
+echo "warning: unknown tool binary name $0 with basename $binary_name" >&2
+exit 1

--- a/configuration/backends/cbmc/cbmc-evaluate.sh
+++ b/configuration/backends/cbmc/cbmc-evaluate.sh
@@ -1,0 +1,47 @@
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+
+# Evaluate and return non-zero in case of failure
+function evaluate_cbmc
+{
+  local -r LOGDIR="$WORKINGDIR/log"
+  local UNWIND=1
+  local DEPTH=250
+  local -r SRC_DIR="$( dirname "${BASH_SOURCE[0]}" )"
+
+  # check whether there are environment variables that control the cbmc behavior
+  [ -z "$CBMC_UNWIND" ] || UNWIND="$CBMC_UNWIND"
+  [ -z "$CBMC_DEPTH" ] || DEPTH="$CBMC_DEPTH"
+
+  mkdir -p "$LOGDIR"
+
+  # collect all binaries and link them against the produced libraries
+  log "perform analyze on binaries ($(cat $WORKINGDIR/binaries.list 2> /dev/null | wc -l))"
+  mkdir -p $WORKINGDIR/log
+  local ANALYSISRESULT=0
+  for f in $(cat $WORKINGDIR/binaries.list 2>/dev/null)
+  do
+    # try analysis only if the binary (still) exists
+    if [ ! -x $f ]
+    then
+      continue
+    fi
+
+    log "analyze $f via $SRC_DIR/inspect-binary.sh $ANALYSIS_OPTIONS --logdir $LOGDIR $f "$BINARY_ORIGIN" $UNWIND $DEPTH"
+    # use pretty simple analysis here
+    $SCRIPT_CALLER $SRC_DIR/inspect-binary.sh $ANALYSIS_OPTIONS --logdir "$LOGDIR" $f "$BINARY_ORIGIN" $UNWIND $DEPTH
+    EXITSTATUS=$?
+    [ $ANALYSISRESULT -ne 0 ] || ANALYSISRESULT=$EXITSTATUS
+  done
+  return $ANALYSISRESULT
+}

--- a/configuration/backends/cbmc/gotocc-hook-install.sh
+++ b/configuration/backends/cbmc/gotocc-hook-install.sh
@@ -1,0 +1,189 @@
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# This file is meant to be sourced by the setup script that installs all
+# selected wrapper hooks. Hence, it contains variables that are not defined in
+# this script.
+
+# install the hook
+inject_gotocc()
+{
+  # use source dir to be able to copy the correct wrapper script
+  local -r HOOK_SRC_DIR="$( dirname "${BASH_SOURCE[0]}" )"
+
+  # check whether we can find the wrapper script
+  if [ ! -f $HOOK_SRC_DIR/gotocc-wrapper.sh ]
+  then
+    echo "error: cannot find wrapper script $HOOK_SRC_DIR/gotocc-wrapper.sh"
+    return 1
+  fi
+
+  # handle all prefixes. i.e. no prefix and the potentially specified prefix
+  for SUFFIX in "" $TOOLSUFFIX
+  do
+  for PREFIX in "" $TOOLPREFIX
+  do
+    # exclude the case where both prefix and suffix are active
+    [ -z "$SUFFIX" ] || [ -z "$PREFIX" ] || continue
+
+    # load compilers wrt prefix:
+    if [ "$GOTO_GCC_NATIVE_COMPILER" != "/bin/true" ]
+    then
+      load_compilers "$PREFIX" "$SUFFIX"
+    fi
+
+    if [ -n "$(which "${PREFIX}gcc${SUFFIX}")" ] && [ $(which "${PREFIX}gcc${SUFFIX}") = "$GOTO_GCC_WRAPPER_INSTALL_DIR/"$PREFIX"gcc${SUFFIX}" ]
+    then
+      echo "error: installing wrapper would result in infinite loop - abort"
+      return 1
+    fi
+
+    # copy the wrapper
+    cp "$HOOK_SRC_DIR/gotocc-wrapper.sh" "$GOTO_GCC_WRAPPER_INSTALL_DIR/"$PREFIX"gcc${SUFFIX}"
+
+    # allow execution
+    chmod a+x "$GOTO_GCC_WRAPPER_INSTALL_DIR/""$PREFIX"gcc"${SUFFIX}"
+
+    # place the actual names to the tools to be used in the wrappers, as well as the directory
+    perl -p -i -e "s:XX/usr/bin/gccXX:$GOTO_GCC_NATIVE_COMPILER:" "$GOTO_GCC_WRAPPER_INSTALL_DIR/"$PREFIX"gcc${SUFFIX}"
+    perl -p -i -e "s:XX/usr/bin/ldXX:$GOTO_GCC_NATIVE_LINKER:" "$GOTO_GCC_WRAPPER_INSTALL_DIR/"$PREFIX"gcc${SUFFIX}"
+    perl -p -i -e "s:XX/usr/bin/arXX:$GOTO_GCC_NATIVE_AR:" "$GOTO_GCC_WRAPPER_INSTALL_DIR/"$PREFIX"gcc${SUFFIX}"
+
+    perl -p -i -e "s:XX/usr/bin/goto-gccXX:$GOTO_GCC_BINARY:" "$GOTO_GCC_WRAPPER_INSTALL_DIR/"$PREFIX"gcc${SUFFIX}"
+    perl -p -i -e "s:XX/usr/bin/goto-ldXX:$GOTO_LD_BINARY:" "$GOTO_GCC_WRAPPER_INSTALL_DIR/"$PREFIX"gcc${SUFFIX}"
+    perl -p -i -e "s:XX/usr/bin/goto-diffXX:$GOTO_DIFF_BINARY:" "$GOTO_GCC_WRAPPER_INSTALL_DIR/"$PREFIX"gcc${SUFFIX}"
+
+    perl -p -i -e "s:XX/tmp/goto-gcc-wrapper-lockXX:$FULLDIRECTORY/wrapper-lock:" "$GOTO_GCC_WRAPPER_INSTALL_DIR/"$PREFIX"gcc${SUFFIX}"
+
+    # tell the wrapper about the current tool prefix and suffix
+    [ -z "$PREFIX" ] || perl -p -i -e "s:TOOLPREFIX=:TOOLPREFIX=$PREFIX:" "$GOTO_GCC_WRAPPER_INSTALL_DIR/"$PREFIX"gcc${SUFFIX}"
+    [ -z "$SUFFIX" ] || perl -p -i -e "s:TOOLSUFFIX=:TOOLSUFFIX=$SUFFIX:" "$GOTO_GCC_WRAPPER_INSTALL_DIR/"$PREFIX"gcc${SUFFIX}"
+
+    # configure include warnings
+    perl -p -i -e "s:INCLUDE_WARNINGS=:INCLUDE_WARNINGS=$INCLUDE_WARNINGS:" "$GOTO_GCC_WRAPPER_INSTALL_DIR/"$PREFIX"gcc${SUFFIX}"
+
+    # set number of locks!
+    perl -p -i -e "s:NUM_LOCKS=4:NUM_LOCKS=$NUM_LOCKS:" "$GOTO_GCC_WRAPPER_INSTALL_DIR/"$PREFIX"gcc${SUFFIX}"
+
+    # add extra arguments to wrapper script
+    if [ -n "$GCC_WRAPPER_EXTRAARGUMENTS" ]
+    then
+        perl -p -i -e "s:^GCCEXTRAARGUMENTS=:GCCEXTRAARGUMENTS=\"$GCC_WRAPPER_EXTRAARGUMENTS\":" "$GOTO_GCC_WRAPPER_INSTALL_DIR/"$PREFIX"gcc${SUFFIX}"
+        echo "use extra arguments: $GCC_WRAPPER_EXTRAARGUMENTS"
+    fi
+
+    if [ -z "$GOTO_GCC_WRAPPER_ENFORCE_GOTO_LINKING" ]
+    then
+        perl -p -i -e "s:^ENFORCE_GOTO_LINKING=1$:ENFORCE_GOTO_LINKING=:" "$GOTO_GCC_WRAPPER_INSTALL_DIR/"$PREFIX"gcc${SUFFIX}" 2> /dev/null
+    fi
+
+    # optional tools that will be handled specially within the compiler wrapper
+    for o in bcc as as86
+    do
+      O=$(echo $o | tr '[a-z]+' '[A-Z]P')
+      if which "$PREFIX"$o"$SUFFIX" > /dev/null 2>&1
+      then
+        perl -p -i -e "s:^NATIVE_$O=:NATIVE_$O=$(which "$PREFIX"$o 2> /dev/null):" "$GOTO_GCC_WRAPPER_INSTALL_DIR/""$PREFIX"gcc"$SUFFIX"
+        which goto-$o > /dev/null 2>&1 && perl -p -i -e "s:XX/usr/bin/goto-${o}XX:$(which goto-$o 2> /dev/null):" "$GOTO_GCC_WRAPPER_INSTALL_DIR/""$PREFIX"gcc"$SUFFIX"
+        cp "$GOTO_GCC_WRAPPER_INSTALL_DIR/""$PREFIX"gcc"$SUFFIX" "$GOTO_GCC_WRAPPER_INSTALL_DIR/""$PREFIX"$o"$SUFFIX"
+      fi
+    done
+
+    # if we find further compilers, also use them. currently, we simply pass the extra options
+    for t in g++ clang clang++
+    do
+      T=$(echo $t | tr '[a-z]+' '[A-Z]P')
+      if which "$PREFIX"$t"$SUFFIX" > /dev/null 2>&1
+      then
+        perl -p -i -e "s:^NATIVE_COMPILER_$T=:NATIVE_COMPILER_$T=$(which "$PREFIX"$t"$SUFFIX" 2> /dev/null):" "$GOTO_GCC_WRAPPER_INSTALL_DIR/""$PREFIX"gcc"$SUFFIX"
+        cp "$GOTO_GCC_WRAPPER_INSTALL_DIR/""$PREFIX"gcc"$SUFFIX" "$GOTO_GCC_WRAPPER_INSTALL_DIR/""$PREFIX"$t"$SUFFIX"
+      elif [ -n "$NESTED" ]
+      then
+        perl -p -i -e "s:^NATIVE_COMPILER_$T=\$:NATIVE_COMPILER_$T=/bin/true:" "$GOTO_GCC_WRAPPER_INSTALL_DIR/""$PREFIX"gcc"$SUFFIX"
+        cp "$GOTO_GCC_WRAPPER_INSTALL_DIR/""$PREFIX"gcc"$SUFFIX" "$GOTO_GCC_WRAPPER_INSTALL_DIR/""$PREFIX"$t"$SUFFIX"
+      fi
+    done
+
+    # also use the wrapper for ld, ar, cc, c++
+    for t in ld ar cc c++
+    do
+      cp "$GOTO_GCC_WRAPPER_INSTALL_DIR/""$PREFIX"gcc"$SUFFIX" "$GOTO_GCC_WRAPPER_INSTALL_DIR/""$PREFIX"$t"$SUFFIX"
+    done
+  done
+  done
+
+  # add wrapper for make, if KEEP_GOING_IN_MAKE option is set
+  if [ -n "$KEEP_GOING_IN_MAKE" ]
+  then
+    if [ -n "$(which make)" ]
+    then
+      echo "$(which make) -k \"\$@\"" > "$GOTO_GCC_WRAPPER_INSTALL_DIR/make"
+      chmod a+x "$GOTO_GCC_WRAPPER_INSTALL_DIR/make"
+    else
+      echo "warning: should add -k to make, but did not find make"
+    fi
+  fi
+
+  # Some GCC packages ship x86_64-unknown-linux-gnu-gcc, but do not include
+  # x86_64-unknown-linux-gnu-objcopy
+  if [ -n "$NESTED" ]
+  then
+    FORWARDS+=("x86_64-unknown-linux-gnu-objcopy")
+    FORWARDS+=("objcopy")
+  fi
+
+  # install all user specified forwards
+  if [ ${#FORWARDS[@]} -gt 0 ]
+  then
+    for i in $(seq 0 2 $((${#FORWARDS[@]} - 1)) )
+    do
+      SRC="${FORWARDS[$i]}"
+      DST="${FORWARDS[$((i+1))]}"
+      if which "$DST" > /dev/null 2>&1
+      then
+        echo "$(which "$DST" 2> /dev/null) \"\$@\"" > "$GOTO_GCC_WRAPPER_INSTALL_DIR"/"$SRC"
+        chmod a+x "$GOTO_GCC_WRAPPER_INSTALL_DIR"/"$SRC"
+      else
+        echo "error: cannot forward $SRC to $DST, as $DST does not exist on the PATH"
+      fi
+    done
+  fi
+
+  # install a wrapper for cflags
+  if [ -n "$NESTED" ]
+  then
+    cp "$HOOK_SRC_DIR/../cflags/cflags-wrapper.sh" "$GOTO_GCC_WRAPPER_INSTALL_DIR/cflags"
+    perl -p -i -e "s:XX/tmp/cflags-wrapper-lockXX:$FULLDIRECTORY/wrapper-lock:" "$GOTO_GCC_WRAPPER_INSTALL_DIR/cflags"
+  fi
+
+  # tell environment about new installation directory
+  export PATH="$GOTO_GCC_WRAPPER_INSTALL_DIR:$PATH"
+
+  # check whether hook worked
+  NEW_GCC="$(which gcc)"
+  NEW_LD="$(which ld)"
+
+  if [ ! "$NEW_GCC" == "$GOTO_GCC_WRAPPER_INSTALL_DIR/gcc" ]
+  then
+    echo "error: failed to install goto-gcc wrapper for gcc: $NEW_GCC vs $GOTO_GCC_WRAPPER_INSTALL_DIR/gcc"
+    # remove wrapper again
+    source remove-wrapper.sh $KEEP_DIRECTORY
+  elif [ ! "$NEW_LD" == "$GOTO_GCC_WRAPPER_INSTALL_DIR/ld" ]
+  then
+    echo "error: failed to install goto-gcc wrapper for ld: $NEW_LD vs $GOTO_GCC_WRAPPER_INSTALL_DIR/ld"
+    # remove wrapper again
+    source remove-wrapper.sh $KEEP_DIRECTORY
+  else
+    echo "success: INSTALLED wrapper to $GOTO_GCC_WRAPPER_INSTALL_DIR"
+  fi
+}

--- a/configuration/backends/cbmc/gotocc-wrapper.sh
+++ b/configuration/backends/cbmc/gotocc-wrapper.sh
@@ -1,0 +1,672 @@
+#!/bin/bash
+#
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Lock wrapping call to goto-cc, to avoid too high memory consumption
+#
+
+# useful for debugging the tool chain
+#USE_GDB="gdb --args"
+#ECHOCOMMAND="echo"
+ECHOCOMMAND="true" # use a command that simply consumes all arguments
+# if log file is not empty, store logging in wrapper-log.txt in the wrapper installation directory
+LOG=log
+#GOTO_CC_EXTRA_ARGUMENTS="--verbosity 10"
+
+
+
+#################### DO NOT MODIFY ##################
+
+# global variables, will be modified during setup.sh
+#
+NATIVE_COMPILER=XX/usr/bin/gccXX
+NATIVE_LINKER=XX/usr/bin/ldXX
+NATIVE_AR=XX/usr/bin/arXX
+GOTO_GCC_BINARY=XX/usr/bin/goto-gccXX
+GOTO_BCC_BINARY=XX/usr/bin/goto-bccXX
+GOTO_LD_BINARY=XX/usr/bin/goto-ldXX
+GOTO_DIFF_BINARY=XX/usr/bin/goto-diffXX
+GOTO_AS_BINARY=XX/usr/bin/goto-asXX
+GOTO_AS86_BINARY=XX/usr/bin/goto-as86XX
+NATIVE_BCC=
+NATIVE_AS=
+NATIVE_AS86=
+# arguments that should be added to the compiler (DO NOT TOUCH)
+GCCEXTRAARGUMENTS=
+ENFORCE_GOTO_LINKING=1
+NUM_LOCKS=4
+TOOLPREFIX=
+TOOLSUFFIX=
+INCLUDE_WARNINGS=
+
+# simply wrap these two, to later be able to have statistics
+NATIVE_COMPILER_GPP=
+NATIVE_COMPILER_CLANG=
+NATIVE_COMPILER_CLANGPP=
+
+# directory name used to lock concurrent access
+LOCKDIR=XX/tmp/goto-gcc-wrapper-lockXX
+WRAPPERPIDFILE=/tmp/goto-gcc-wrapper-pid
+TRAPDIR=
+
+# load the library
+SCRIPT=$(readlink -e "$0")
+source $(dirname $SCRIPT)/ols-library.sh || exit 1
+
+# store the binary in binaries.list; only, if we do not use an intermediate file
+function storeBinary
+{
+  use_next=0
+  outputfile="a.out"
+  [ "$PERSONALITY" != "AR" ] || outputfile="/dev/null"
+  for a in "$@"
+  do
+    case "$a" in
+      -E|-c|-S) return 0 ;;
+      -o) use_next=1 ;;
+      -b) [ "$PERSONALITY" != "AS86" ] || use_next=1 ;;
+      -o*) outputfile=$(echo $a | sed 's/^-o//') ;;
+      -b*) [ "$PERSONALITY" != "AS86" ] || outputfile=$(echo $a | sed 's/^-o//') ;;
+      *.a)
+        if [ $use_next -eq 1 ] || [ "$PERSONALITY" = "AR" ]
+        then
+          use_next=0
+          outputfile=$a
+        fi
+        ;;
+      *)
+        if [ $use_next -eq 1 ]
+        then
+          use_next=0
+          outputfile=$a
+        fi
+        ;;
+    esac
+  done
+
+  case "$outputfile" in
+    /dev/null) return 0 ;;
+    *.so|*.a) full_path "$outputfile" >> $LOCK_PARENT_DIR/libraries.list ;;
+    *) full_path "$outputfile" >> $LOCK_PARENT_DIR/binaries.list ;;
+  esac
+}
+
+# for certain binaries, no goto-ld section is required
+# hence, select the output file from ld and remove the goto-cc section
+function strip_goto ()
+{
+  logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "check strip-goto for $@"
+  use_next=0
+  outputfile="a.out"
+  for a in "$@"
+  do
+    case "$a" in
+      -o) use_next=1 ;;
+      -o*) outputfile=$(echo $a | sed 's/^-o//') ;;
+      *)
+        if [ $use_next -eq 1 ]
+        then
+          use_next=0
+          outputfile=$a
+        fi
+        ;;
+    esac
+  done
+  if [ -f "$outputfile" ] && [[ "$(basename "$outputfile")" =~ .xen.efi.(.*).0 ]]
+  then
+    logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "remove goto section from $(readlink -e "$outputfile")"
+    objcopy -R goto-cc "$outputfile" "${outputfile}.removed-gotocc"
+    mv "${outputfile}.removed-gotocc" "${outputfile}"
+  fi
+}
+
+# check the compiler commandline, and print the md5sum of the output binary, as
+# well as the full location
+function logOutputfileHash()
+{
+  local BINARY="$(basename "$1")"
+  shift
+  use_next=0
+  outputfile="a.out"
+  [ "$PERSONALITY" != "AR" ] || outputfile="/dev/null"
+  for a in "$@"
+  do
+    case "$a" in
+      -o) use_next=1 ;;
+      -b) [ "$PERSONALITY" != "AS86" ] || use_next=1 ;;
+      -o*) outputfile=$(echo $a | sed 's/^-o//') ;;
+      -b*) [ "$PERSONALITY" != "AS86" ] || outputfile=$(echo $a | sed 's/^-o//') ;;
+      *.a)
+        if [ $use_next -eq 1 ] || [ "$PERSONALITY" = "AR" ]
+        then
+          use_next=0
+          outputfile=$a
+        fi
+        ;;
+      *)
+        if [ $use_next -eq 1 ]
+        then
+          use_next=0
+          outputfile=$a
+        fi
+        ;;
+    esac
+  done
+
+  case "$outputfile" in
+    /dev/null) return 0 ;;
+    *)         [ ! -f "$outputfile" ] || logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "tool $BINARY wrote output file $(full_path "$outputfile") with md5 $(md5sum "$outputfile" | cut -d' ' -f1)" ;;
+  esac
+}
+
+# test whether we are pre-processing only -- just call the native tool in that
+# case
+function preprocess_only
+{
+  if [ "$PERSONALITY" != "CC" ]
+  then
+    return 1
+  fi
+
+  for a in "$@"
+  do
+    if [ "x$a" = "x-E" ]
+    then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# store the binary in binaries.list; only, if we do not use an intermediate file
+function checkIncludes
+{
+  [ "$PERSONALITY" = "CC" ] || return 0
+
+  local goto_cc="$1"
+  local native_cc="$2"
+  shift 2
+
+  # build a new compiler command line to be used with a single source file at
+  # a time; compile only, and output to a newly chosen file
+  local NEW_ARGV=( )
+  local skip_next=0
+  local source_files=( )
+  for a in "$@"
+  do
+    [ $skip_next -eq 0 ] || continue
+    case "$a" in
+      -E|-c|-S) true ;;
+      -o) skip_next=1 ;;
+      -o*) true ;;
+      -*) NEW_ARGV+=( "$a" ) ;;
+      *.c|*.C) source_files+=( "$a" ) ;;
+      *) NEW_ARGV+=( "$a" ) ;;
+    esac
+  done
+
+  if [ ${#source_files[@]} -eq 0 ]
+  then
+    return 0
+  fi
+
+  set -- "${NEW_ARGV[@]}" -c
+
+  # try to compile each source file and compare the compilation result to the
+  # original source's result, using goto-diff
+  for f in "${source_files[@]}" ; do
+    local rf=$(full_path "$f")
+    local rd=$(dirname "$rf")
+    local tmpfile=$(TMPDIR="$rd" mktemp -t include-checkXXXXXX)
+    local TMPFILES=( "$tmpfile" )
+
+    if ! grep -q "^[[:space:]]*#include" "$f"
+    then
+      rm -f "${TMPFILES[@]}"
+      continue
+    fi
+
+    TMPFILES+=( "$tmpfile.c" )
+    TMPFILES+=( "$tmpfile.o" )
+    TMPFILES+=( "${tmpfile}-i.o" )
+    cp "$f" "$tmpfile.c"
+    if ! $goto_cc --native-compiler $native_cc "$@" "$tmpfile.c" -o "$tmpfile.o" \
+      >  >(tee -a "$LOG") \
+      2> >(tee -a "$LOG" 1>&2)
+    then
+      rm -f "${TMPFILES[@]}"
+      return 1
+    fi
+
+    for l in $(grep -n "^[[:space:]]*#include" "$f" | cut -f1 -d:)
+    do
+      cat "$f" | sed "${l}s/.*/ /" > "$tmpfile.c"
+      $goto_cc --native-compiler $native_cc "$@" "$tmpfile.c" -o "$tmpfile.o" \
+        >/dev/null 2>&1 || continue
+      local inc=$(sed -n "${l}p" "$f" | \
+                  sed -e 's/^.*#include[[:space:]]*[<"]//' \
+                      -e 's/[>"][[:space:]]*$//')
+      if $GOTO_DIFF_BINARY -u "$tmpfile.o" "${tmpfile}-i.o" | grep -q "^[+-]"
+      then
+        echo "$f:$l: warning: code compiles both with and without $inc, but instructions differ" \
+          | tee -a "$LOG"
+      else
+        echo "$f:$l: warning: (not) including $inc has no effect" \
+          | tee -a "$LOG"
+      fi
+    done
+
+    rm -f "${TMPFILES[@]}"
+  done
+}
+
+#
+# start of the script
+#
+# redirect stdin to another file descriptor (here we picked 4), and close stdin afterwards
+# use this to pass stdin to the actual compiler call, and not to tools used before
+REDIRECT_STDIN=0
+if [ -t 0 ]
+then
+  REDIRECT_STDIN=1
+  exec 4<&0
+  exec 0<&-
+fi
+
+# the directory, in which the lock directory should be created, has to exist
+# otherwise the wrapper is broken (and the locking mkdir would block forever)
+LOCK_PARENT_DIR="$(dirname $LOCKDIR)"
+if [ ! -d "$LOCK_PARENT_DIR" ]
+then
+  echo "error: goto-gcc wrapper is broken" >&2
+  exit 1
+fi
+
+# set actual logfile
+if [ -z "$LOG" ]
+then
+  LOG="/dev/null"
+else
+  LOG="$LOCK_PARENT_DIR/wrapper-log.txt"
+fi
+
+binary_name=$(basename $0)
+
+PERSONALITY=CC
+case "$binary_name" in
+  "$TOOLPREFIX""ar${TOOLSUFFIX}") PERSONALITY=AR ;;
+  "$TOOLPREFIX""ld${TOOLSUFFIX}") PERSONALITY=LD ;;
+  "$TOOLPREFIX""as86") PERSONALITY="AS86" ;;
+  "$TOOLPREFIX""as${TOOLSUFFIX}") PERSONALITY=AS ;;
+esac
+
+# check whether some parent is the wrapper already
+parent_result=0
+called_by_wrapper $$ || parent_result=$?
+
+# grep for patterns that should not be run through the analysis
+# grep "linux" $@ > /dev/null 2>&1
+# pattern_result=$?
+
+# logging
+logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "called $binary_name as $$ with $0 $@"
+logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "parent is wrapper: $parent_result"
+
+if [ "$parent_result" == 0 ] && preprocess_only "$@"
+then
+  logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "preprocessing only"
+  parent_result=1
+fi
+
+# if wrapper is already active somewhere in the calling tree, call original program
+if [ "$parent_result" == "1" ]
+then
+  case "$binary_name" in
+    "$TOOLPREFIX""ar${TOOLSUFFIX}")
+      if [ "$NATIVE_AR" = "/bin/true" ]
+      then
+        NATIVE_AR=$(next_in_path $binary_name)
+      fi
+      logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "call native $NATIVE_AR $@"
+      [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+      $NATIVE_AR "$@"
+      EXITSTATUS=$?
+      logOutputfileHash "$NATIVE_AR" "$@"
+      exit $EXITSTATUS
+      ;;
+    "$TOOLPREFIX""ld${TOOLSUFFIX}")
+      if [ "$NATIVE_LINKER" = "/bin/true" ]
+      then
+        NATIVE_LINKER=$(next_in_path $binary_name)
+      fi
+      logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "call native $NATIVE_LINKER $@"
+      [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+      $NATIVE_LINKER "$@"
+      EXITSTATUS=$?
+      logOutputfileHash "$NATIVE_LINKER" "$@"
+      exit $EXITSTATUS
+      ;;
+    "$TOOLPREFIX""cc${TOOLSUFFIX}" | "$TOOLPREFIX""gcc${TOOLSUFFIX}")
+      logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "NATIVE_COMPILER preset: $NATIVE_COMPILER"
+      if [ "$NATIVE_COMPILER" = "/bin/true" ]
+      then
+        NATIVE_COMPILER=$(next_in_path $binary_name)
+        logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "NATIVE_COMPILER next-in-path: $NATIVE_COMPILER"
+        # Some GCC packages ship x86_64-unknown-linux-gcc, but do not ship
+        # x86_64-unknown-linux-objcopy, as would be expected by goto-gcc. Fix
+        # this on-demand
+        if [ "$(basename $NATIVE_COMPILER)" = "x86_64-unknown-linux-gnu-gcc" ]
+        then
+          objcopy_path=$(echo $NATIVE_COMPILER | sed 's/-gcc$/-objcopy/')
+          if ! which "$objcopy_path" &>/dev/null
+          then
+            logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "installing objcopy symlink at $objcopy_path"
+            ln -sf $(dirname $objcopy_path)/objcopy "$objcopy_path"
+          fi
+        fi
+      fi
+      logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "call native $NATIVE_COMPILER $@"
+      [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+      $NATIVE_COMPILER "$@"
+      EXITSTATUS=$?
+      logOutputfileHash "$NATIVE_COMPILER" "$@"
+      exit $EXITSTATUS
+      ;;
+    "$TOOLPREFIX""bcc${TOOLSUFFIX}")
+      if [ "$NATIVE_BCC" = "/bin/true" ]
+      then
+        NATIVE_BCC=$(next_in_path $binary_name)
+      fi
+      logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "call native $NATIVE_BCC $@"
+      [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+      $NATIVE_BCC "$@"
+      EXITSTATUS=$?
+      logOutputfileHash "$NATIVE_BCC" "$@"
+      exit $EXITSTATUS
+      ;;
+    "$TOOLPREFIX""as86")
+      if [ "$NATIVE_AS86" = "/bin/true" ]
+      then
+        NATIVE_AS86=$(next_in_path $binary_name)
+      fi
+      logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "call native $NATIVE_AS86 $@"
+      [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+      $NATIVE_AS86 "$@"
+      EXITSTATUS=$?
+      logOutputfileHash "$NATIVE_AS86" "$@"
+      exit $EXITSTATUS
+      ;;
+    "$TOOLPREFIX""as${TOOLSUFFIX}")
+      if [ "$NATIVE_AS" = "/bin/true" ]
+      then
+        NATIVE_AS=$(next_in_path $binary_name)
+      fi
+      logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "call native $NATIVE_AS $@"
+      [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+      $NATIVE_AS "$@"
+      EXITSTATUS=$?
+      logOutputfileHash "$NATIVE_AS" "$@"
+      exit $EXITSTATUS
+      ;;
+    "$TOOLPREFIX""g++${TOOLSUFFIX}")
+      if [ "$NATIVE_COMPILER_GPP" = "/bin/true" ]
+      then
+        NATIVE_COMPILER_GPP=$(next_in_path $binary_name)
+      fi
+      logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "call native $NATIVE_COMPILER_GPP $@"
+      [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+      $NATIVE_COMPILER_GPP "$@"
+      EXITSTATUS=$?
+      logOutputfileHash "$@"
+      exit $EXITSTATUS
+      ;;
+    "$TOOLPREFIX""clang${TOOLSUFFIX}")
+      if [ "$NATIVE_COMPILER_CLANG" = "/bin/true" ]
+      then
+        NATIVE_COMPILER_CLANG=$(next_in_path $binary_name)
+      fi
+      logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "call native $NATIVE_COMPILER_CLANG $@"
+      [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+      $NATIVE_COMPILER_CLANG "$@"
+      EXITSTATUS=$?
+      logOutputfileHash "$NATIVE_COMPILER_CLANG" "$@"
+      exit $EXITSTATUS
+      ;;
+    "$TOOLPREFIX""clang++${TOOLSUFFIX}")
+      if [ "$NATIVE_COMPILER_CLANGPP" = "/bin/true" ]
+      then
+        NATIVE_COMPILER_CLANGPP=$(next_in_path $binary_name)
+      fi
+      logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "call native $NATIVE_COMPILER_CLANGPP $@"
+      [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+      $NATIVE_COMPILER_CLANGPP "$@"
+      EXITSTATUS=$?
+      logOutputfileHash "$NATIVE_COMPILER_CLANGPP" "$@"
+      exit $EXITSTATUS
+      ;;
+  esac
+
+  # make sure we do not enter the goto-gcc path again, if there are spaces
+  echo "warning: unknown (child) compiler binary name $0 with basename $binary_name" >&2
+  exit 1
+fi
+
+# free the lock and the parent pid file in case something gets wrong
+trap exit_handler EXIT
+
+# tell that we are using the wrapper now with the current PID
+touch "$WRAPPERPIDFILE$$"
+
+# if we wrap g++, clang or clang++, update NATIVE_COMPILER
+case "$binary_name" in
+  "$TOOLPREFIX""g++${TOOLSUFFIX}")
+    logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "NATIVE_COMPILER_GPP: $NATIVE_COMPILER_GPP"
+    NATIVE_COMPILER=$NATIVE_COMPILER_GPP
+    ;;
+  "$TOOLPREFIX""clang${TOOLSUFFIX}")
+    logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "NATIVE_COMPILER_CLANG: $NATIVE_COMPILER_CLANG"
+    NATIVE_COMPILER=$NATIVE_COMPILER_CLANG
+    ;;
+  "$TOOLPREFIX""clang++${TOOLSUFFIX}")
+    logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "NATIVE_COMPILER_CLANGPP: $NATIVE_COMPILER_CLANGPP"
+    NATIVE_COMPILER=$NATIVE_COMPILER_CLANGPP
+    ;;
+esac
+
+# build directory to check whether we have the lock, do not print errors, iterate over 2 locks
+PICKLOCK=$(($$ % $NUM_LOCKS))
+BASELOCKDIR="$LOCKDIR"
+LOCKDIR="$BASELOCKDIR$PICKLOCK"
+while ! mkdir "$LOCKDIR" 2> /dev/null
+do
+  HOLDINGPID=$(cat $LOCKDIR/pid 2> /dev/null)
+  logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "PID $$ with name $binary_name waits for the lock held by $HOLDINGPID"
+  # try the next lock
+  PICKLOCK=$((($PICKLOCK + 1) % $NUM_LOCKS))
+
+  # busy waiting, not putting too much load on the file system
+  if [ $PICKLOCK -eq 0 ]
+  then
+    sleep 1
+  fi
+  LOCKDIR="$BASELOCKDIR$PICKLOCK"
+done
+
+# record the pid of the process who took the lock
+echo "lock taken by PID $$ with name $binary_name" >> $LOCKDIR/info.txt
+echo "$$" >> $LOCKDIR/pid
+
+# tell trap about the directory only after we actually hold the lock
+TRAPDIR="$LOCKDIR"
+
+# cleanup is performed by exit handler
+logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "use goto-gcc (PID $$,calling basename: $binary_name) with --native-linker $NATIVE_LINKER $@ $GCCEXTRAARGUMENTS"
+case "$binary_name" in
+  "$TOOLPREFIX""ar${TOOLSUFFIX}")
+    if [ "$NATIVE_AR" = "/bin/true" ]
+    then
+      NATIVE_AR=$(next_in_path $binary_name)
+    fi
+    logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "create archive: $NATIVE_AR $@"
+    [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+    ar_code=0
+    $NATIVE_AR "$@" || ar_code=$?
+    logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "ar (PID $$) exit code: $ar_code"
+    if [ "$ar_code" == "0" ]
+    then
+        storeBinary "$@"
+    fi
+    logOutputfileHash "$NATIVE_AR" "$@"
+    exit $ar_code
+    ;;
+  "$TOOLPREFIX""ld${TOOLSUFFIX}")
+    if [ "$NATIVE_LINKER" = "/bin/true" ]
+    then
+      NATIVE_LINKER=$(next_in_path $binary_name)
+    fi
+    logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "call linker $GOTO_LD_BINARY"
+    [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+    ld_code=0
+    FINALLINKBINARY="$GOTO_LD_BINARY"
+    $USE_GDB $GOTO_LD_BINARY $GOTO_CC_EXTRA_ARGUMENTS --native-compiler $NATIVE_COMPILER --native-linker $NATIVE_LINKER "$@" || ld_code=$?
+    logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "$FINALLINKBINARY (PID $$) exit code: $ld_code"
+    # if no linking with goto-ld should be enforced, fall back in case of errors
+    if [ "$ld_code" -ne 0 ] && [ "$ld_code" -ne 134 ] &&  [ "$ld_code" -ne 139 ] && [ -z "$ENFORCE_GOTO_LINKING" ]
+    then
+        logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "linking with goto-ld failed with $ld_code, retry with native linker $NATIVE_LINKER"
+        ld_code=0
+        FINALLINKBINARY="$NATIVE_LINKER"
+        $NATIVE_LINKER "$@" || ld_code=$?
+        logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "$NATIVE_LINKER (PID $$) exit code: $ld_code"
+    fi
+    if [ "$ld_code" == "0" ]
+    then
+        storeBinary "$@"
+    fi
+    strip_goto "$@"
+    logOutputfileHash "$FINALLINKBINARY" "$@"
+    exit $ld_code
+    ;;
+  "$TOOLPREFIX""cc${TOOLSUFFIX}" | "$TOOLPREFIX""gcc${TOOLSUFFIX}" | "$TOOLPREFIX""bcc${TOOLSUFFIX}" | "$TOOLPREFIX""g++${TOOLSUFFIX}" | "$TOOLPREFIX""clang${TOOLSUFFIX}" | "$TOOLPREFIX""clang++${TOOLSUFFIX}")
+    logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "NATIVE_COMPILER preset: $NATIVE_COMPILER"
+    if [ "$NATIVE_COMPILER" = "/bin/true" ]
+    then
+      NATIVE_COMPILER=$(next_in_path $binary_name)
+      logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "NATIVE_COMPILER next-in-path: $NATIVE_COMPILER"
+      # Some GCC packages ship x86_64-unknown-linux-gcc, but do not ship
+      # x86_64-unknown-linux-objcopy, as would be expected by goto-gcc. Fix
+      # this on-demand
+      if [ "$(basename $NATIVE_COMPILER)" = "x86_64-unknown-linux-gnu-gcc" ]
+      then
+        objcopy_path=$(echo $NATIVE_COMPILER | sed 's/-gcc$/-objcopy/')
+        if ! which "$objcopy_path" &>/dev/null
+        then
+          logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "installing objcopy symlink at $objcopy_path"
+          ln -sf $(dirname $objcopy_path)/objcopy "$objcopy_path"
+        fi
+      fi
+    fi
+    if [ $binary_name = "$TOOLPREFIX""bcc${TOOLSUFFIX}" ] && [ "$NATIVE_BCC" = "/bin/true" ]
+    then
+      NATIVE_BCC=$(next_in_path $binary_name)
+    fi
+    # set the compiler to bcc, if the called compiler is actually bcc
+    USE_COMPILER="$NATIVE_COMPILER"
+    USE_GOTO_COMPILER="$GOTO_GCC_BINARY"
+    # when bcc should be used, set goto-bcc and native bcc tools
+    [ $binary_name = "$TOOLPREFIX""bcc${TOOLSUFFIX}" ] && [ -n "$NATIVE_BCC" ] && USE_COMPILER="$NATIVE_BCC"
+    [ $binary_name = "$TOOLPREFIX""bcc${TOOLSUFFIX}" ] && USE_GOTO_COMPILER="$GOTO_BCC_BINARY"
+    logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "call compiler $USE_GOTO_COMPILER with --native-compiler $USE_COMPILER"
+    FAULTYINPUT=$(mktemp faulty-goto-gcc-input-for-$$.XXXXXX)
+    [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+    # here, output to stdout and stderr is added to the same log file with two
+    # different tee processes. While this might mix up lines in the log, for the
+    # moment we go with this simple version
+    gcc_code=0
+    $USE_GDB $USE_GOTO_COMPILER $GOTO_CC_EXTRA_ARGUMENTS --print-rejected-preprocessed-source "$FAULTYINPUT" \
+             --native-compiler $USE_COMPILER --native-linker $NATIVE_LINKER "$@" $GCCEXTRAARGUMENTS \
+             >  >(tee -a "$LOG") \
+             2> >(tee -a "$LOG" 1>&2) || gcc_code=$?
+    logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "goto-gcc (PID $$) exit code: $gcc_code"
+    if [ "$gcc_code" == "0" ]
+    then
+        storeBinary "$@"
+        # delete created faulty input file, as we do not need it
+        rm -f "$FAULTYINPUT"
+
+        if [ -n "$INCLUDE_WARNINGS" ]
+        then
+          checkIncludes $USE_GOTO_COMPILER $USE_COMPILER "$@" || gcc_code=$?
+        fi
+    else
+        if [ -s "$FAULTYINPUT" ]
+        then
+            mkdir -p "$LOCK_PARENT_DIR/faultyInput"
+            mv "$FAULTYINPUT" "$LOCK_PARENT_DIR/faultyInput/$(basename "$FAULTYINPUT")"
+            logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "stored input for failed gcc call with PID $$ at: $LOCK_PARENT_DIR/faultyInput/$(basename $FAULTYINPUT)"
+        else
+            rm -f "$FAULTYINPUT"
+        fi
+    fi
+    logOutputfileHash "$USE_GOTO_COMPILER" "$@"
+    exit $gcc_code
+    ;;
+  "$TOOLPREFIX"as"${TOOLSUFFIX}" | "$TOOLPREFIX"as86"${TOOLSUFFIX}" )
+    if [ "$NATIVE_AS" = "/bin/true" ]
+    then
+      NATIVE_AS=$(next_in_path $binary_name)
+    fi
+    USE_ASSEMBLER="$NATIVE_AS"
+    USE_GOTO_COMPILER="$GOTO_AS_BINARY"
+    if [ $binary_name = "$TOOLPREFIX"as86 ]
+    then
+      if [ "$NATIVE_AS86" = "/bin/true" ]
+      then
+        NATIVE_AS86=$(next_in_path $binary_name)
+      fi
+      USE_ASSEMBLER="$NATIVE_AS86"
+      USE_GOTO_COMPILER="$GOTO_AS86_BINARY"
+    fi
+    logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "call compiler $USE_GOTO_COMPILER with --native-assembler $USE_ASSEMBLER"
+    FAULTYINPUT=$(mktemp faulty-goto-gcc-input-for-$$.XXXXXX)
+    [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+    # here, output to stdout and stderr is added to the same log file with two
+    # different tee processes. While this might mix up lines in the log, for the
+    # moment we go with this simple version
+    gcc_code=0
+    $USE_GDB $USE_GOTO_COMPILER $GOTO_CC_EXTRA_ARGUMENTS --print-rejected-preprocessed-source "$FAULTYINPUT" \
+             --native-assembler $USE_ASSEMBLER "$@" \
+             >  >(tee -a "$LOG") \
+             2> >(tee -a "$LOG" 1>&2) || gcc_code=$?
+    logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "goto-gcc (PID $$) exit code: $gcc_code"
+    if [ "$gcc_code" == "0" ]
+    then
+        storeBinary "$@"
+        # delete created faulty input file, as we do not need it
+        rm -f "$FAULTYINPUT"
+    else
+        mkdir -p "$LOCK_PARENT_DIR/faultyInput"
+        mv "$FAULTYINPUT" "$LOCK_PARENT_DIR/faultyInput/$(basename "$FAULTYINPUT")"
+        logwrapper "${TOOLPREFIX}"GOTO-GCC"${TOOLSUFFIX}" "stored input for failed gcc call with PID $$ at: $LOCK_PARENT_DIR/faultyInput/$(basename $FAULTYINPUT)"
+    fi
+    logOutputfileHash "$USE_GOTO_COMPILER" "$@"
+    exit $gcc_code
+    ;;
+esac
+
+# make sure we do not enter the goto-gcc path again
+# cleanup is performed by exit handler
+echo "warning: unknown tool binary name $0 with basename $binary_name" >&2
+exit 1

--- a/configuration/backends/cbmc/inspect-binary.sh
+++ b/configuration/backends/cbmc/inspect-binary.sh
@@ -1,0 +1,345 @@
+#!/bin/bash
+#
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Analyze a single binary with the given options
+#
+# Usage:
+# See usage() function below, or just run the script without parameters
+
+# locate the script to be able to call related scripts
+SCRIPT=$(readlink -e "$0")
+SCRIPTDIR=$(dirname "$SCRIPT")
+
+set -eux
+
+# limit the memory that can be used when being executed by this script
+source $SCRIPTDIR/../../utils/limit-resources.sh
+limit_memory
+
+#
+# execute a given command and store Wall time, CPU time, CPU utilization, used memory
+# currently this relies on the command /usr/bin/time being available
+# otherwise, no measurement is reported
+#
+measured_execution ()
+{
+  OUTPUT_FILE="$1"
+  shift
+  COMMAND="$@"
+
+  EXIT_CODE=0
+  if [ -x /usr/bin/time ]
+  then
+    /usr/bin/time -f %e\ %U\ %P\ %M --output="$OUTPUT_FILE" $COMMAND || EXIT_CODE=$?
+  else
+    $COMMAND || EXIT_CODE=$?
+    echo "- - - -" > "$OUTPUT_FILE"
+  fi
+  return $EXIT_CODE
+}
+
+usage()
+{
+	cat << EOF
+usage:
+inspect-binary.sh [OPTIONS] binary source-of-binary loop-unwind-limit depth
+
+  binary            ... location to the binary
+  source-of-binary  ... where does the binary come from
+  loop-unwind-limit ... how much loop unrolling should be performed during the analysis
+  depth             ... how long should the maximum reachable path be
+
+OPTIONS:
+  --logdir DIR      ... directory to store the logs
+  --symex           ... use symex instead of cbmc (symbolic execution instead of BMC model checking)
+  --timeout SEC     ... allow only SEC seconds for the analysis, or abort
+  --library         ... treat target as library, start analysis from multiple entry points ( all functions with no parameter )
+EOF
+}
+
+# start with an empty directory for logging, that can be overwritten by a default value later
+LOGDIR=
+TOOL=cbmc
+TIMEOUT=
+LIBRARY=
+
+# parse arguments
+while [ $# -gt 0 ]
+do
+    case $1 in
+    --logdir)   LOGDIR="$2"; shift;;
+    --symex)    TOOL=symex;;
+    --help |-h) usage
+                exit 0;;
+    --timeout)  TIMEOUT="$2"; shift;;
+    --library)  LIBRARY=t;;
+           *)   break; ;;
+    esac
+    shift
+done
+
+FILENAME=$1
+SOURCELOCATION=$2
+UNWIND=$3
+DEPTH=$4
+
+# check number of parameters
+if [ -z $DEPTH ]
+then
+  usage
+  exit 1
+fi
+
+# check whether cbmc and goto-instrument are available in the PATH
+if ! command -v goto-instrument > /dev/null 2>&1
+then
+	echo "error: cannot find goto-instrument - abort" 1>&2
+	exit 1
+fi
+
+# generic check for the selected tool
+if ! command -v "$TOOL" > /dev/null 2>&1
+then
+	echo "error: cannot find $TOOL - abort" 1>&2
+	exit 1
+fi
+
+# setup a working directory, and temporary file
+TMPDIR=$(mktemp -d)
+TMP=$(mktemp)
+TMPPROPERTIES=$(mktemp)
+
+# call this when exiting the script
+# cleans up the used files
+exit_handler()
+{
+  rm -rf $TMPDIR $TMP $TMPPROPERTIES
+}
+
+# install the exit handler
+trap exit_handler EXIT
+
+# handle to the binary
+BINARYNAME=$(basename $FILENAME)
+TARGETBINARY=$TMPDIR/$BINARYNAME
+
+# load functions for logging
+. "$SCRIPTDIR/../../utils/log.sh"
+
+#
+# DEFINITIONS FOR THE SCRIPT
+#
+# log versions (including their headers)
+PROPERTYLOGVERSION=2
+#TIMEMETRICS=WallTime CPUTime CPUutilization MaxMemory
+# header = "$PROPERTYLOGVERSION $TIMESTAMP show-properties $SOURCELOCATION $BINARYNAME $ANALYSIS_RESULT $PROPERTIES $SHORTESTPATH WallTime CPUTime CPUutilization MaxMemory"
+ANALYZEALLLOGVERSION=4
+# header = "$ANALYZEALLLOGVERSION $TIMESTAMP analyzse-all-properties $SOURCELOCATION $BINARYNAME $function $UNWIND $DEPTH $ANALYSIS_RESULT $FAILEDPROPERTIES WallTime CPUTime CPUutilization MaxMemory"
+ANALYZESINGLELOGVERSION=3
+# header = "$ANALYZESINGLELOGVERSION $TIMESTAMP analyzse-single-property $SOURCELOCATION $BINARYNAME $function $UNWIND $DEPTH $ANALYSIS_RESULT $p $COUNTEREXAMPLESTEPS $DECISIONPROCEDURETIME WallTime CPUTime CPUutilization MaxMemory"
+ANALYZESYMEXVERSION=2
+# header = "$ANALYZESYMEXVERSION $TIMESTAMP symex $SOURCELOCATION $BINARYNAME $function $UNWIND $DEPTH $LOG_TIMEOUT $ANALYSIS_RESULT $COUNTER_EXAMPLES TOTAL_PROPERTIES WallTime CPUTime CPUutilization MaxMemory"
+# basic log location
+if [ -z $LOGDIR ]
+then
+	LOGDIR=$SCRIPTDIR/log
+fi
+
+# make sure the logging directory exists
+mkdir -p $LOGDIR
+
+#
+# instrument the binary
+#
+INSTRUMENT_ERROR=$(mktemp)
+log "instrument binary $FILENAME, write result to $TARGETBINARY"
+INSTRUMENT_STATUS=0
+goto-instrument --bounds-check --pointer-check --memory-leak-check \
+                --signed-overflow-check --div-by-zero-check --undefined-shift-check \
+                --nan-check --float-overflow-check --stack-depth 10 \
+                --model-argc-argv 4 --conversion-check \
+                $FILENAME $TARGETBINARY > $INSTRUMENT_ERROR 2>&1 || INSTRUMENT_STATUS=$?
+log "instrumenting the binary finished with status: $INSTRUMENT_STATUS"
+if [ $INSTRUMENT_STATUS -ne 0 ]
+then
+  echo "abort due to unsuccessful binary instrumentation" 1>&2
+  cat $INSTRUMENT_ERROR
+  rm -f $INSTRUMENT_ERROR
+  exit $INSTRUMENT_STATUS
+fi
+rm -f $INSTRUMENT_ERROR
+
+#
+# show properties of the binary
+#
+# use logs
+PROPERTYLOG="$LOGDIR/cbmc-properties.log"
+SINGLEPROPERTYLOG="$LOGDIR/properties/$BINARYNAME.log"
+mkdir -p $(dirname $SINGLEPROPERTYLOG)
+
+# list all available properties
+ANALYSIS_RESULT=0
+measured_execution $TMP cbmc --show-properties $TARGETBINARY \
+  > "$SINGLEPROPERTYLOG" 2>&1 || ANALYSIS_RESULT=$?
+log "property analysis ended with $ANALYSIS_RESULT"
+TIMEMETRICS=$(cat $TMP)
+TIMESTAMP=$(( $(date +%s%N) / 1000000 ))
+# collect number of all properties
+PROPERTIES=$(grep "^Property " $SINGLEPROPERTYLOG | wc -l)
+# also go for path properties
+goto-instrument --print-path-lengths $TARGETBINARY >> "$SINGLEPROPERTYLOG" 2>&1
+SHORTESTPATH=$(grep "^Shortest control-flow path:" "$SINGLEPROPERTYLOG" | awk '{print $4}')
+# make sure the date ends up in the log
+LOGENTRY="$TIMESTAMP show-properties $SOURCELOCATION $BINARYNAME $ANALYSIS_RESULT $PROPERTIES $SHORTESTPATH $TIMEMETRICS"
+echo "$LOGENTRY" >> "$PROPERTYLOG"
+
+#
+# analyze whether properties fail (given unwinding and search depth limitation)
+#
+# use logs
+ALLLOG="$LOGDIR/cbmc-allproperties.log"
+SINGLELOG="$LOGDIR/cbmc-singleproperty.log"
+SYMEXLOG="$LOGDIR/symex.log"
+VIOLATION_OUTPUT="$LOGDIR/violation/$BINARYNAME-d$DEPTH-uw$UNWIND.$TOOL.log"
+mkdir -p $(dirname "$VIOLATION_OUTPUT")
+
+# as CBMC currently does not support specifying a timeout, wrap the call with
+# the timeout tool, that kills CBMC after the given amount of time
+TIMEOUT_CALL=
+if [ -n "$TIMEOUT" ]
+then
+  log "set timeout to $TIMEOUT"
+  TIMEOUT_CALL="/usr/bin/timeout -s KILL $TIMEOUT"
+fi
+
+# store all starting points (functions) in the following file
+FUNCTIONS=$(mktemp)
+if [ -z "$LIBRARY" ]
+then
+  # in case its a binary, we want to start scanning starting with the main function (and it has to be the first function)
+  goto-instrument --list-symbols $TARGETBINARY | awk '{print $1}' | grep "^main$" 2> /dev/null > $FUNCTIONS;
+else
+  # in case of a library, we furthermore want to scan from other functions, currently only the ones without parameters
+  goto-instrument --list-symbols $TARGETBINARY | grep "(void)" 2> /dev/null | awk '{print $1}' >> $FUNCTIONS;
+fi
+NUM_FUNCTIONS=$(cat $FUNCTIONS | wc -l)
+log "will perform analysis on $NUM_FUNCTIONS entry points"
+
+# iterate over all functions / entry points and perform analysis
+# as C conventions do not alow spaces in function names, a simple for loop works here
+NUM_ENTRYPOINT=1
+for function in $(cat $FUNCTIONS)
+do
+  log "perform scan on entry point $NUM_ENTRYPOINT / $NUM_FUNCTIONS : function $function"
+  NUM_ENTRYPOINT=$(($NUM_ENTRYPOINT+1))
+
+  # choose form of analysis
+  if [ "$TOOL" = "cbmc" ]
+  then
+
+    # perform analysis to check whether properties fail, ignore dependent libraries for now
+    rm -f $TMP
+    ANALYSIS_RESULT=0
+    measured_execution $TMP \
+      $TIMEOUT_CALL \
+      cbmc --unwind $UNWIND --verbosity 8 --depth $DEPTH \
+      --all-properties $TARGETBINARY   \
+      --function $function \
+      > "$VIOLATION_OUTPUT" 2>&1 || ANALYSIS_RESULT=$?
+    log "checking for failed properties ended with $ANALYSIS_RESULT"
+    TIMEMETRICS=$(tail -n 1 $TMP)
+    TIMESTAMP=$(( $(date +%s%N) / 1000000 ))
+
+    # look for failed properties
+    grep ": FAILURE$"  $VIOLATION_OUTPUT | awk '{print $1}' | sed s:^.::g | sed s:]$::g > $TMPPROPERTIES
+    FAILEDPROPERTIES=$(cat $TMPPROPERTIES | wc -l)
+
+    # make sure the date ends up in the log
+    LOGENTRY="$TIMESTAMP analyzse-all-properties $SOURCELOCATION $BINARYNAME $function \
+      $UNWIND $DEPTH $ANALYSIS_RESULT $FAILEDPROPERTIES $TIMEMETRICS"
+    log "stored log: $VIOLATION_OUTPUT"
+    echo "$LOGENTRY" >> "$ALLLOG"
+
+    #
+    # iterate over all single properties and create counter examples for them
+    #
+    iteration=1
+    mkdir -p "$LOGDIR/violation/single"
+    for p in $(cat $TMPPROPERTIES)
+    do
+      FAILEDPROPERTYLOG="$LOGDIR/violation/single/$BINARYNAME-d$DEPTH-uw$UNWIND.log-failure$iteration.log"
+
+      rm -f $TMP
+      ANALYSIS_RESULT=0
+      measured_execution $TMP \
+        $TIMEOUT_CALL \
+        cbmc --unwind $UNWIND --verbosity 8 --depth $DEPTH \
+        --property $p $TARGETBINARY      \
+        --function $function
+        >> "$FAILEDPROPERTYLOG" 2>&1 || ANALYSIS_RESULT=$?
+      # echo "Wall CPU CPUutilization Memory(kB)" >> $TASKDIR/build-metrics.log
+      log "counter example generation for ($iteration / $FAILEDPROPERTIES) ended with $ANALYSIS_RESULT"
+      TIMEMETRICS=$(tail -n 1 $TMP)
+      TIMESTAMP=$(( $(date +%s%N) / 1000000 ))
+      # count number of steps in counter example
+      COUNTEREXAMPLESTEPS=$(grep "^State " "$FAILEDPROPERTYLOG" | tail -n 1 | awk '{if ($2 != "") print $2; else print "-"}')
+      DECISIONPROCEDURETIME=$(grep "Runtime decision procedure: " "$FAILEDPROPERTYLOG" | awk '{print $4 * 1}')
+
+      LOGENTRY="$TIMESTAMP analyzse-single-property $SOURCELOCATION $BINARYNAME $function \
+        $UNWIND $DEPTH $ANALYSIS_RESULT $p $COUNTEREXAMPLESTEPS $DECISIONPROCEDURETIME $TIMEMETRICS"
+      echo "$LOGENTRY" >> "$SINGLELOG"
+
+      iteration=$(($iteration+1))
+    done
+  # we have TOOL != cbmc
+  else
+    # test for timeout, and enable the tool side timeout if possible
+    ANALYSIS_TIME=
+    if [ -n "$TIMEOUT" ] && [ $TIMEOUT -gt 10 ]
+    then
+      ANALYSIS_TIME="--max-search-time $(($TIMEOUT-10))"
+    fi
+
+    # perform analysis to check whether properties fail, ignore dependent libraries for now
+    rm -f $TMP
+    TIMEOUT_CALL= # disable timeout call when using symex
+    log "run: symex $TARGETBINARY"
+    ANALYSIS_RESULT=0
+    measured_execution $TMP \
+      symex \
+      $ANALYSIS_TIME \
+      $TARGETBINARY   \
+      --unwind $UNWIND --depth $DEPTH \
+      --function $function \
+      > "$VIOLATION_OUTPUT" 2>&1 || ANALYSIS_RESULT=$?
+    #for now, use the full "power" of symex without any limitations, otherwise: --unwind $UNWIND --depth $DEPTH
+    log "checking for failed properties ended with $ANALYSIS_RESULT"
+    TIMEMETRICS=$(tail -n 1 $TMP)
+    TIMESTAMP=$(( $(date +%s%N) / 1000000 ))
+    LOG_TIMEOUT=-
+    [ -n "$TIMEOUT" ] && LOG_TIMEOUT=$TIMEOUT
+    COUNTER_EXAMPLES=$(grep -e "^\*\* [0-9]\+ of [0-9]\+ failed$" "$VIOLATION_OUTPUT" 2> /dev/null | awk '{print $2,$4}')
+    [ -n "$COUNTER_EXAMPLES" ] || COUNTER_EXAMPLES="- -"
+    LOGENTRY="$TIMESTAMP symex $SOURCELOCATION $BINARYNAME $function $UNWIND $DEPTH \
+      $LOG_TIMEOUT $ANALYSIS_RESULT $COUNTER_EXAMPLES $TIMEMETRICS"
+    log "stored log: $VIOLATION_OUTPUT"
+    echo "$LOGENTRY" >> "$SYMEXLOG"
+    exit $ANALYSIS_RESULT
+  fi
+
+done
+
+# clean up
+rm -f $FUNCTIONS

--- a/configuration/backends/cflags/cflags-wrapper.sh
+++ b/configuration/backends/cflags/cflags-wrapper.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+#
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+
+#ECHOCOMMAND="echo"
+ECHOCOMMAND="true" # use a command that simply consumes all arguments
+# if log file is not empty, store logging in wrapper-log.txt in the wrapper installation directory
+LOG=log
+
+#################### DO NOT MODIFY ##################
+# directory name used to lock concurrent access
+LOCKDIR=XX/tmp/cflags-wrapper-lockXX
+WRAPPERPIDFILE=/tmp/cflags-wrapper-pid
+TRAPDIR=
+
+# load the library
+SCRIPT=$(readlink -e "$0")
+source $(dirname $SCRIPT)/ols-library.sh || exit 1
+
+#
+# start of the script
+#
+# redirect stdin to another file descriptor (here we picked 4), and close stdin afterwards
+# use this to pass stdin to the actual compiler call, and not to tools used before
+REDIRECT_STDIN=0
+if [ -t 0 ]
+then
+  REDIRECT_STDIN=1
+  exec 4<&0
+  exec 0<&-
+fi
+
+# the directory, in which the lock directory should be created, has to exist
+# otherwise the wrapper is broken (and the locking mkdir would block forever)
+LOCK_PARENT_DIR="$(dirname $LOCKDIR)"
+if [ ! -d "$LOCK_PARENT_DIR" ]
+then
+  echo "error: cflags wrapper is broken" >&2
+  exit 1
+fi
+
+# set actual logfile
+if [ -z "$LOG" ]
+then
+  LOG="/dev/null"
+else
+  LOG="$LOCK_PARENT_DIR/wrapper-log.txt"
+fi
+
+binary_name=$(basename $0)
+
+# check whether some parent is the wrapper already
+parent_result=0
+called_by_wrapper $$ || parent_result=$?
+
+# logging
+logwrapper CFLAGS "called $binary_name as $$ with $0 $@"
+logwrapper CFLAGS "parent is wrapper: $parent_result"
+
+# if wrapper is already active somewhere in the calling tree, call original program
+if [ "$parent_result" == "1" ]
+then
+  NATIVE_CFLAGS=$(next_in_path $binary_name)
+  logwrapper CFLAGS "call native $NATIVE_CFLAGS $@"
+  [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+  $NATIVE_CFLAGS "$@"
+  exit $?
+fi
+
+# free the lock and the parent pid file in case something gets wrong
+trap exit_handler EXIT
+
+# tell that we are using the wrapper now with the current PID
+touch "$WRAPPERPIDFILE$$"
+
+# locate gcc and g++ wrappers
+logwrapper CFLAGS "PATH: $PATH"
+NATIVE_CFLAGS=$(next_in_path $binary_name)
+logwrapper CFLAGS "NATIVE_CFLAGS: $NATIVE_CFLAGS"
+NATIVE_CC=$($NATIVE_CFLAGS CC)
+logwrapper CFLAGS "NATIVE_CC: $NATIVE_CC"
+basename_native_cc=$(basename $NATIVE_CC)
+OUR_CC=$(next_in_path $basename_native_cc)
+logwrapper CFLAGS "OUR_CC: $OUR_CC"
+NATIVE_CXX=$($NATIVE_CFLAGS CXX)
+logwrapper CFLAGS "NATIVE_CXX: $NATIVE_CXX"
+basename_native_cxx=$(basename $NATIVE_CXX)
+OUR_CXX=$(next_in_path $basename_native_cxx)
+logwrapper CFLAGS "OUR_CXX: $OUR_CXX"
+
+# adjust the wrappers if they 1) genuinely are ours and 2) they haven't been
+# touched yet and 3) the native CC/CXX is provided as full path by cflags
+if echo $NATIVE_CC | grep -q "^/"
+then
+  if [ "$(file -b "$OUR_CC")" = "Bourne-Again shell script, ASCII text executable" ]
+  then
+    if grep -q "^NATIVE_COMPILER=/bin/true$" "$OUR_CC"
+    then
+      perl -p -i -e "s:NATIVE_COMPILER=/bin/true:NATIVE_COMPILER=$NATIVE_CC:" "$OUR_CC"
+    fi
+    if grep -q "^NATIVE_GCC=/bin/true$" "$OUR_CC"
+    then
+      perl -p -i -e "s:NATIVE_GCC=/bin/true:NATIVE_GCC=$NATIVE_CC:" "$OUR_CC"
+    fi
+  fi
+fi
+
+if echo $NATIVE_CXX | grep -q "^/"
+then
+  if [ "$(file -b "$OUR_CXX")" = "Bourne-Again shell script, ASCII text executable" ]
+  then
+    wrapped_cxx=$(grep -q "^NATIVE_COMPILER_GPP=.\+$" "$OUR_CXX" | cut -f2 -d"=")
+    if [ -n "$wrapped_cxx" ] && [ "$wrapped_cxx" != "$NATIVE_CXX" ]
+    then
+      perl -p -i -e "s:NATIVE_COMPILER_GPP=.*:NATIVE_COMPILER_GPP=$NATIVE_CXX:" "$OUR_CXX"
+    fi
+    wrapped_cxx=$(grep -q "^NATIVE_GPP=.\+$" "$OUR_CXX" | cut -f2 -d"=")
+    if [ -n "$wrapped_cxx" ] && [ "$wrapped_cxx" != "$NATIVE_CXX" ]
+    then
+      perl -p -i -e "s:NATIVE_GPP=.*:NATIVE_GPP=$NATIVE_CXX:" "$OUR_CXX"
+    fi
+  fi
+fi
+
+# parse the options and see whether we need to handle this call
+FORMAT=make
+format_is_next=0
+skip_next=0
+VARIABLE=
+
+for arg in "$@"
+do
+  case "$arg" in
+    -flavor) skip_next=0 ;;
+    -format) format_is_next=1 ;;
+    *)
+      if [ $format_is_next -eq 1 ]
+      then
+        FORMAT=$arg
+        format_is_next=0
+      elif [ $skip_next -eq 1 ]
+      then
+        skip_next=0
+      else
+        VARIABLE=$arg
+      fi
+      ;;
+  esac
+done
+
+if [ "$FORMAT" = "sh" ]
+then
+  OUR_CC="'$OUR_CC'"
+  OUR_CXX="'$OUR_CXX'"
+fi
+
+if [ -z "$VARIABLE" ]
+then
+  [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+  logwrapper CFLAGS "subst CC->$OUR_CC/CXX->$OUR_CXX native $NATIVE_CFLAGS $@"
+  $NATIVE_CFLAGS "$@" | \
+    sed "s#CC=.*#CC=$OUR_CC#" | \
+    sed "s#CXX=.*#CXX=$OUR_CXX#"
+  exit ${PIPESTATUS[0]}
+fi
+
+if [ "$VARIABLE" = "CC" ]
+then
+  echo -n $OUR_CC
+elif [ "$VARIABLE" = "CXX" ]
+then
+  echo -n $OUR_CXX
+else
+  [ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+  logwrapper CFLAGS "call native $NATIVE_CFLAGS $@"
+  $NATIVE_CFLAGS "$@"
+fi
+
+if [ "$FORMAT" = "sh" ]
+then
+  echo
+fi
+
+[ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-

--- a/configuration/backends/cppcheck/cppcheck-evaluate.sh
+++ b/configuration/backends/cppcheck/cppcheck-evaluate.sh
@@ -1,0 +1,53 @@
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Evaluate the cppcheck output of an cppcheck analysis run
+
+# Evaluate and return non-zero in case of failure
+function evaluate_cppcheck
+{
+  local -r RESULTS_DIR="$WORKINGDIR/cppcheck/results"
+  local -r LOGDIR="$WORKINGDIR/log"
+  mkdir -p "$LOGDIR"
+  local -r LOGFILE="$LOGDIR/cppcheck.log"
+
+  TOTAL_DEFECTS=0
+  TOTAL_ERRORS=0
+  TOTAL_FILES=$(ls "$RESULTS_DIR/" 2> /dev/null | wc -l)
+
+  ERROR_FILES=
+
+  for f in $(ls "$RESULTS_DIR"/* 2> /dev/null)
+  do
+    DEFECTS=$(cat $f | grep -v "^::" | grep -v "(information) Couldn't find path given by -I" | wc -l)
+    ERRORS=$(grep " (error:" "$f" | wc -l)
+
+    ERROR_FILES+=" $f"
+
+    TOTAL_DEFECTS=$((TOTAL_DEFECTS + DEFECTS))
+    TOTAL_ERRORS=$((TOTAL_ERRORS + ERRORS))
+  done
+
+  log "Cppcheck found $TOTAL_ERRORS errors in $TOTAL_DEFECTS total defects in $TOTAL_FILES files" |& tee "$LOGFILE"
+  echo "ERRORS:" | tee -a "$LOGFILE"
+  [ -z "$ERROR_FILES" ] || grep " (error:" $ERROR_FILES | tee -a "$LOGFILE" || true  # display errors, in case we found some
+  echo "RUNTIME INFO:" | tee -a "$LOGFILE"
+  grep "^::" "$RESULTS_DIR"/* | sort -u | tee -a "$LOGFILE" || true # display cppcheck runtime info (each once)
+  echo "DEFECT DISTRIBUTION:" | tee -a "$LOGFILE"
+  grep -v "^::" "$RESULTS_DIR"/* | grep -v "(information) Couldn't find path given by -I" | \
+    awk '{print $2}' | sort | uniq -c | sort -n -r | tee -a "$LOGFILE"
+  log "Cppcheck results per source file can be found in: $WORKINGDIR/cppcheck/results/" |& tee -a "$LOGFILE"
+
+  [ "$TOTAL_ERRORS" -eq 0 ] || return 1
+  return 0
+}

--- a/configuration/backends/cppcheck/cppcheck-hook-install.sh
+++ b/configuration/backends/cppcheck/cppcheck-hook-install.sh
@@ -1,0 +1,92 @@
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Wrap all compiler calls by an extra step to run cppcheck with all -I and -D
+# flags of the compiler calls.
+#
+# This file is meant to be sourced by the setup script that installs all
+# selected wrapper hooks. Hence, it contains variables that are not defined in
+# this script.
+
+# install the hook.
+inject_cppcheck()
+{
+  # we will place the cppcheck wrapper here
+  local -r TOOL="cppcheck"
+  local -r INSTALL_DIR="$GOTO_GCC_WRAPPER_INSTALL_DIR/$TOOL"
+
+  # use source dir to be able to copy the correct wrapper script
+  local -r HOOK_SRC_DIR="$( dirname "${BASH_SOURCE[0]}" )"
+
+  # check if prerequirements are available
+  if ! command -v "$TOOL" &> /dev/null
+  then
+    echo "could not find $TOOL command, abort"
+    return 1
+  fi
+
+  # check the cppcheck version, and warn if there is a more recent version (at the time of writing)
+  CPPCHECK_VERSION=$(cppcheck --version | cut -d ' ' -f 2)
+  if (( $(echo "$CPPCHECK_VERSION < 1.81" |bc -l) ))
+  then
+    log "Note: there is a more recent cppcheck version, visit http://cppcheck.sourceforge.net/!"
+  fi
+
+  # install wrapper
+  mkdir -p "$INSTALL_DIR"
+  for SUFFIX in "" $TOOLSUFFIX
+  do
+  for PREFIX in "" $TOOLPREFIX
+  do
+    # exclude the case where both prefix and suffix are active
+    [ -z "$SUFFIX" ] || [ -z "$PREFIX" ] || continue
+
+    # we will point all calls to relevant compilers to the same wrapper
+    local TARGET_GCC="$INSTALL_DIR/${PREFIX}gcc${SUFFIX}"
+    cp "$HOOK_SRC_DIR/$TOOL-wrapper.sh" "$TARGET_GCC"
+
+    # add extra arguments to wrapper script
+    if [ ! -z "$GCC_WRAPPER_EXTRAARGUMENTS" ]
+    then
+        perl -p -i -e "s:^GCCEXTRAARGUMENTS=:GCCEXTRAARGUMENTS=\"$GCC_WRAPPER_EXTRAARGUMENTS\":" "$TARGET_GCC"
+    fi
+
+    # tell the wrapper about the location of the actual compilers
+    perl -p -i -e "s:TOOLPREFIX=:TOOLPREFIX=$PREFIX:" "$TARGET_GCC"
+    perl -p -i -e "s:TOOLSUFFIX=:TOOLSUFFIX=$SUFFIX:" "$TARGET_GCC"
+
+    # tell the wrapper from where install has been called
+    perl -p -i -e "s:CALL_DIR=:CALL_DIR=$(readlink -e $(pwd))/:" "$TARGET_GCC"
+
+    for t in gcc g++ clang clang++
+    do
+      T=$(echo $t | tr '[a-z]+' '[A-Z]P')
+      p=$(find_native "$PREFIX"$t"$SUFFIX")
+      perl -p -i -e "s:^NATIVE_$T=.*:NATIVE_$T=$p:" "$TARGET_GCC"
+    done
+
+    # make the other compiler use the fortify wrapper
+    for TARGET_COMPILER in g++ clang clang++ cc c++
+    do
+      # might fail, because if check-setup.sh is used, the directory is already
+      # there, as well as the links
+      cp "$TARGET_GCC" "$INSTALL_DIR/${PREFIX}${TARGET_COMPILER}${SUFFIX}"
+    done
+  done
+  done
+
+  # after using all previous tool locations to setup the wrapper script,
+  # activate the wrapper script
+  export PATH="$INSTALL_DIR":$PATH
+  return 0
+}

--- a/configuration/backends/cppcheck/cppcheck-wrapper.sh
+++ b/configuration/backends/cppcheck/cppcheck-wrapper.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+#
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Call cppcheck with used compiler flags and store output in the log directory.
+# Continue compilation as usual.
+
+#################### DO NOT MODIFY ##################
+
+# by default, all supported tools have not been found.
+NATIVE_GCC=/bin/false
+NATIVE_GPP=/bin/false
+NATIVE_CLANG=/bin/false
+NATIVE_CLANGPP=/bin/false
+TOOLPREFIX=
+TOOLSUFFIX=
+CPPCHECK_EXTRA_ARG=
+CALL_DIR=
+
+
+# options to be passed to cppcheck
+CHECK_CONFIG="--error-exitcode=-1 --quiet --force"
+CHECK_CONFIG+=" --enable=warning --enable=style --enable=performance"
+CHECK_CONFIG+=" --enable=information --enable=portability --inconclusive"
+# CHECK_CONFIG+=" --check-config"  # enable to see problems with setup
+CHECK_CONFIG+="$CPPCHECK_EXTRA_ARG"
+
+# arguments that should be added to the compiler (DO NOT TOUCH)
+GCCEXTRAARGUMENTS=
+
+# base file to check whether the current process has been called by the wrapper
+WRAPPERPIDFILE=/tmp/cppcheck-wrapper-pid
+
+# location of this script
+SCRIPT=$(readlink -e "$0")
+SCRIPTDIR=$(dirname "$SCRIPT")
+LOG="$SCRIPTDIR/cppcheck-preprocess.log"
+
+# load the library
+source $SCRIPTDIR/../ols-library.sh || exit 1
+
+# forwarded options (options of the actual compiler call that should be
+# forwarded to the define expansion call)
+FORWARD_OPTIONS=( )
+
+# preprocess all source files using the provided compiler $1
+function preprocess
+{
+  local compiler="$1"
+  local suffix="$2"
+  local i=0
+  local source_files=( )
+  local skip_next=0
+  local use_next=0
+
+  shift 2
+
+  NEWARGV=( )
+  for a in "$@"
+  do
+    if [ $skip_next -eq 1 ]
+    then
+      skip_next=0
+      continue
+    fi
+    # handle part of split options that have to be forwarded
+    if [ $use_next -eq 1 ]
+    then
+      use_next=0
+      NEWARGV+=( "$a" )
+      continue
+    fi
+
+    # we are only interested in "-I" and "-D"
+    case "$a" in
+      -M|-MM) return 1 ;; # updates make rules only
+      -E) return 0 ;; # invoked as preprocessor, we're not interested
+      -MMD | -MP | -MD) true ;;
+      -MT | -MF) skip_next=1 ;;
+      -c) true ;;
+      -S) true ;;
+      -o) skip_next=1 ;;
+      -o*) true ;;
+      -Wp*) true ;;
+      # collect -D* and -I* without space
+      -D* | -I* ) NEWARGV+=( "$a" );;
+      # handle split options that need to be forwarded
+      -D | -I ) NEWARGV+=( "$a" ); use_next=1;;
+      # options that do not need to be treated specially
+      -*) true ;;
+      # collect files
+      *.c|*.cc|*.cpp|*.c++|*.C) source_files+=( "$a" ) ;;
+      # we are not interested in object files
+      *.o) true ;;
+      *) NEWARGV+=( "$a" ) ;;
+    esac
+  done
+
+  if [ ${#source_files[@]} -eq 0 ]
+  then
+    logwrapper "${TOOLPREFIX}"CPPCHECK"${TOOLSUFFIX}" "no source files found, skip preprocessing"
+    return 1
+  fi
+  
+  # create parameters to be forwarded to cppcheck
+  logwrapper "${TOOLPREFIX}"CPPCHECK"${TOOLSUFFIX}" "set command: set -- ${NEWARGV[@]} -E -o /dev/stdout"
+  set -- "${NEWARGV[@]}" $CHECK_CONFIG
+
+  base=$(readlink -e $SCRIPTDIR/../../)
+  for f in "${source_files[@]}"
+  do
+    # print cppcheck output to a unique file
+    rf=$(readlink -e "$f")
+    [ -z "$CALL_DIR" ] || rf=${rf#$CALL_DIR}
+    rf=$SCRIPTDIR/results/${rf////_} #  ${rf##$base/}
+    mkdir -p $(dirname $rf)
+    logwrapper "${TOOLPREFIX}"CPPCHECK"${TOOLSUFFIX}" "log cppcheck results: $f to $rf"
+    logwrapper "${TOOLPREFIX}"CPPCHECK"${TOOLSUFFIX}" "cppcheck $* --template='{file}:{line}: ({severity}:{id}) {message}' $f"
+    # in case the source file is analyzed multiple times, collect all messages
+    CPPC_STATUS=0
+    cppcheck "$@" --template='{file}:{line}: ({severity}:{id}) {message}' "$f" &>> "$rf" || CPPC_STATUS=$?
+    logwrapper "${TOOLPREFIX}"CPPCHECK"${TOOLSUFFIX}" "cppcheck returned with $CPPC_STATUS"
+  done
+}
+
+#
+# start of the script
+#
+# redirect stdin to another file descriptor (here we picked 4), and close stdin afterwards
+# use this to pass stdin to the actual compiler call, and not to tools used before
+REDIRECT_STDIN=0
+if [ -t 0 ]
+then
+  exec 4<&0
+  exec 0<&-
+  REDIRECT_STDIN=1
+fi
+
+# use the binary name
+binary_name=$(basename $0)
+
+NATIVE_TOOL=
+case "$binary_name" in
+  "$TOOLPREFIX""cc""$TOOLSUFFIX" | "$TOOLPREFIX""gcc""$TOOLSUFFIX") NATIVE_TOOL=$NATIVE_GCC ;;
+  "$TOOLPREFIX""c++""$TOOLSUFFIX" | "$TOOLPREFIX""g++""$TOOLSUFFIX") NATIVE_TOOL=$NATIVE_GPP ;;
+  "$TOOLPREFIX""clang""$TOOLSUFFIX") NATIVE_TOOL=$NATIVE_CLANG ;;
+  "$TOOLPREFIX""clang++""$TOOLSUFFIX") NATIVE_TOOL=$NATIVE_CLANGPP ;;
+  *)
+    logwrapper "${TOOLPREFIX}"CPPCHECK"${TOOLSUFFIX}"  "error: cppcheck wrapper has been called with an unknown tool name: $binary_name"
+    exit 1
+    ;;
+esac
+
+if [ $NATIVE_TOOL = "/bin/true" ]
+then
+  NATIVE_TOOL=$(next_in_path $binary_name cppcheck)
+fi
+
+# check whether some parent is the wrapper already
+called_by_wrapper $$
+parent_result=$?
+
+logwrapper "${TOOLPREFIX}"CPPCHECK"${TOOLSUFFIX}" "called $binary_name with $*, parent is cppcheck wrapper: $parent_result"
+
+# if wrapper is not yet active in the calling tree
+if [ "$parent_result" != "1" ]
+then
+  # free the lock and the parent pid file in case something gets wrong
+  trap exit_handler EXIT
+
+  # tell that we are using the wrapper now with the current PID
+  touch "$WRAPPERPIDFILE$$"
+
+  logwrapper "${TOOLPREFIX}"CPPCHECK"${TOOLSUFFIX}" "preprocessing with $binary_name using $NATIVE_TOOL"
+  # use the actual compiler binary
+  case "$binary_name" in
+    "$TOOLPREFIX""cc""$TOOLSUFFIX" | "$TOOLPREFIX""gcc""$TOOLSUFFIX" | \
+      "$TOOLPREFIX""clang" )
+      preprocess "$NATIVE_TOOL" "c" "$@"
+      ;;
+    "$TOOLPREFIX""c++""$TOOLSUFFIX" | "$TOOLPREFIX""g++""$TOOLSUFFIX" | "$TOOLPREFIX""clang++""$TOOLSUFFIX" )
+      preprocess "$NATIVE_TOOL" "cpp" "$@"
+      ;;
+    *)
+      logwrapper "${TOOLPREFIX}"CPPCHECK"${TOOLSUFFIX}"  "error: cppcheck wrapper has been called with an unknown tool name: $binary_name"
+      exit 1
+      ;;
+  esac
+fi
+
+logwrapper "${TOOLPREFIX}"CPPCHECK"${TOOLSUFFIX}" "call native $NATIVE_TOOL $@"
+[ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+$NATIVE_TOOL "$@" $GCCEXTRAARGUMENTS

--- a/configuration/backends/fortify/fortify-evaluate.sh
+++ b/configuration/backends/fortify/fortify-evaluate.sh
@@ -1,0 +1,47 @@
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+
+# Evaluate and return non-zero in case of failure
+function evaluate_fortify
+{
+  local -r SRC_DIR="$( dirname "${BASH_SOURCE[0]}" )"
+
+  $SCRIPT_CALLER "$SRC_DIR"/fortify-scan.sh $ANALYSIS_OPTIONS $FORTIFY_ANALYSIS_CONFIG \
+    --logdir "$WORKINGDIR"/log "$BINARY_ORIGIN" $WORKINGDIR/fortify-data
+  ANALYSISRESULT=$?
+
+  # summarize the results, if an html is present
+  if [ -f "$WORKINGDIR"/log/report.html ]
+  then
+    python "$SRC_DIR"/summarize-fortify.py $WORKINGDIR \
+      >> $WORKINGDIR/log/fortify-summary.txt || touch $WORKINGDIR/log/fortify-summary.txt
+
+    if [ -n $GITUPSTREAM ]
+    then
+      $SCRIPT_CALLER "$SCRIPTDIR"/utils/display-series-data.sh \
+        "$WORKINGDIR/log/fortify-summary.txt" $GITUPSTREAM $GITBRANCH \
+        > $WORKINGDIR/log/fortify-summary-filtered.txt
+      FILTER_STATUS=$?
+      # on the given git commit range, no defects mean successful analysis
+      if [ $FILTER_STATUS -eq 0 ] && [ $ANALYSISRESULT -eq 10 ]
+      then
+        ANALYSISRESULT=0
+      fi
+    fi
+  else
+    touch $WORKINGDIR/log/fortify-summary.txt
+  fi
+  log "Fortify summary and FPR file can be found at: $WORKINGDIR/log"
+
+  return $ANALYSISRESULT
+}

--- a/configuration/backends/fortify/fortify-hook-install.sh
+++ b/configuration/backends/fortify/fortify-hook-install.sh
@@ -1,0 +1,91 @@
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# This file is meant to be sourced by the setup script that installs all
+# selected wrapper hooks. Hence, it contains variables that are not defined in
+# this script.
+
+# Wrap the Fortify's sourceanalyzer around all further (goto-)gcc calls.
+# sourceanalyzer strictly requires that the name of the compiler is gcc,
+# thus all prefixes require extra care.
+#
+inject_fortify()
+{
+  # use source dir to be able to copy the correct wrapper script
+  local -r HOOK_SRC_DIR="$( dirname "${BASH_SOURCE[0]}" )"
+
+  # check whether we can find the wrapper script
+  if [ ! -f $HOOK_SRC_DIR/fortify-wrapper.sh ]
+  then
+    echo "error: cannot find wrapper script $HOOK_SRC_DIR/fortify-wrapper.sh"
+    return 1
+  fi
+
+  # if we can't find sourceanalyzer on the path, we cannot continue
+  if ! which sourceanalyzer > /dev/null 2>&1
+  then
+    echo "error: cannot inject Fortify wrapper as sourceanalyzer cannot be found on PATH"
+    return 1
+  fi
+
+  # we will place the Fortify wrapper here
+  mkdir -p "$GOTO_GCC_WRAPPER_INSTALL_DIR/Fortify"
+  for SUFFIX in "" $TOOLSUFFIX
+  do
+  for PREFIX in "" $TOOLPREFIX
+  do
+    # exclude the case where both prefix and suffix are active
+    [ -z "$SUFFIX" ] || [ -z "$PREFIX" ] || continue
+
+    # we will point all calls to relevant compilers to the same wrapper
+    local TARGET_GCC="$GOTO_GCC_WRAPPER_INSTALL_DIR/Fortify/$PREFIX""gcc""$SUFFIX"
+    cp "$HOOK_SRC_DIR"/fortify-wrapper.sh "$TARGET_GCC"
+
+    # add extra arguments to wrapper script
+    if [ -n "$GCC_WRAPPER_EXTRAARGUMENTS" ]
+    then
+        perl -p -i -e "s:^GCCEXTRAARGUMENTS=:GCCEXTRAARGUMENTS=\"$GCC_WRAPPER_EXTRAARGUMENTS\":" "$TARGET_GCC"
+    fi
+
+    local FORTIFY_BUILD_ID=$(echo "$ORIGIN" | sed 's%[:/#@]%_%g')
+    local FORTIFY_OPTS="-Dcom.fortify.WorkingDirectory=$FULLDIRECTORY/fortify-data -Dcom.fortify.sca.ProjectRoot=$FULLDIRECTORY/fortify-data"
+
+    # find sourceanalyzer
+    perl -p -i -e "s:NATIVE_SCA_PATH=:NATIVE_SCA_PATH=$(which sourceanalyzer 2> /dev/null):" "$TARGET_GCC"
+    perl -p -i -e "s:FORTIFY_BUILD_ID=.*:FORTIFY_BUILD_ID=$FORTIFY_BUILD_ID:" "$TARGET_GCC"
+    perl -p -i -e "s:FORTIFY_OPTS=.*:FORTIFY_OPTS=\"$FORTIFY_OPTS\":" "$TARGET_GCC"
+    # tell the wrapper about the location of the actual compilers
+    perl -p -i -e "s:TOOLPREFIX=:TOOLPREFIX=$PREFIX:" "$TARGET_GCC"
+    perl -p -i -e "s:TOOLSUFFIX=:TOOLSUFFIX=$SUFFIX:" "$TARGET_GCC"
+    for t in gcc g++ clang clang++
+    do
+      T=$(echo $t | tr '[a-z]+' '[A-Z]P')
+      p=$(find_native "$PREFIX"$t"$SUFFIX")
+      perl -p -i -e "s:^NATIVE_$T=.*:NATIVE_$T=$p:" "$TARGET_GCC"
+    done
+
+    # make the other compiler use the fortify wrapper
+    for TOOL in g++ clang clang++ cc c++
+    do
+      # might fail, because if check-setup.sh is used, the directory is already
+      # there, as well as the links
+      cp "$TARGET_GCC" "$GOTO_GCC_WRAPPER_INSTALL_DIR/Fortify/$PREFIX""$TOOL""$SUFFIX"
+    done
+  done
+  done
+
+  # after using all previous tool locations to setup the wrapper script,
+  # activate the wrapper script
+  export PATH="$GOTO_GCC_WRAPPER_INSTALL_DIR/Fortify":$PATH
+  return 0
+}

--- a/configuration/backends/fortify/fortify-scan.sh
+++ b/configuration/backends/fortify/fortify-scan.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+#
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Scan a codebase using Fortify
+#
+# Usage:
+# See usage() function below, or just run the script without parameters
+
+# locate the script to be able to call related scripts
+SCRIPT=$(readlink -e "$0")
+SCRIPTDIR=$(dirname "$SCRIPT")
+
+# load functions for logging
+. "$SCRIPTDIR/../../utils/log.sh"
+
+RULEDIRS=
+
+# limit the memory that can be used when being executed by this script
+source $SCRIPTDIR/../../utils/limit-resources.sh
+
+#
+# execute a given command and store Wall time, CPU time, CPU utilization, used memory
+# currently this relies on the command /usr/bin/time being available
+# otherwise, no measurement is reported
+#
+measured_execution ()
+{
+  OUTPUT_FILE="$1"
+  shift
+  COMMAND="$@"
+
+  if [ -x /usr/bin/time ]
+  then
+    echo "measure in ${PWD}: /usr/bin/time -f %e\ %U\ %P\ %M --output=$OUTPUT_FILE $COMMAND"
+    /usr/bin/time -f %e\ %U\ %P\ %M --output="$OUTPUT_FILE" $COMMAND
+    EXIT_CODE=$?
+  else
+    $COMMAND
+    EXIT_CODE=$?
+    echo "- - - -" > "$OUTPUT_FILE"
+  fi
+  return $EXIT_CODE
+}
+
+usage()
+{
+	cat << EOF
+usage:
+fortify-scan.sh [OPTIONS] source-of-project data-directory
+
+  source-of-project ... origin of source code, determines build id
+  data-directory    ... Fortify build data
+
+OPTIONS:
+  --logdir DIR      ... directory to store the logs
+  --rules DIR       ... directory or file with additional rules (specify multiple times)
+  --symex           ... ignored for compatibility
+  --timeout SEC     ... allow only SEC seconds for the analysis, or abort
+EOF
+}
+
+# start with an empty directory for logging, that can be overwritten by a default value later
+LOGDIR=
+TIMEOUT=
+
+# parse arguments
+while [ $# -gt 0 ]
+do
+    case $1 in
+    --logdir)   LOGDIR="$2"; shift;;
+    --symex)    true;;
+    --help |-h) usage
+                exit 0;;
+    --timeout)  TIMEOUT="$2"; shift;;
+    --rules)    if [ -n "$2" ]
+                then
+                  RULEDIRS="$RULEDIRS -rules $2"
+                  shift
+                else
+                  log "warning: specified --rules parameter without value"
+                fi
+                ;;
+           *)   break; ;;
+    esac
+    shift
+done
+
+ORIGIN=$1
+DATADIR=$2
+
+# check number of parameters
+if [ -z $DATADIR ]
+then
+  usage
+  exit 1
+fi
+
+# generic check for the selected tool
+if ! command -v "sourceanalyzer" > /dev/null 2>&1
+then
+	echo "error: cannot find sourceanalyzer - abort" 1>&2
+	exit 1
+fi
+
+# setup a working directory, and temporary file
+TMP=$(mktemp)
+
+# call this when exiting the script
+# cleans up the used files
+exit_handler()
+{
+  rm -rf $TMP
+}
+
+# install the exit handler
+trap exit_handler EXIT
+
+#
+# DEFINITIONS FOR THE SCRIPT
+#
+# basic log location
+if [ -z "$LOGDIR" ]
+then
+	LOGDIR=$SCRIPTDIR/log
+fi
+
+# load wrapper library
+source "$SCRIPTDIR/../../inject-gcc-wrapper/ols-library.sh"
+
+# indicate whether we actually performed a scan
+ANALYSIS_HAPPENED=t
+
+# make sure the logging directory exists
+mkdir -p $LOGDIR
+AVAILABLE_MEM="$(usable_memory_in_M)"
+log "limit memory of Fortify to ${AVAILABLE_MEM}M"
+FORTIFY_BUILD_ID=$(echo "$ORIGIN" | sed 's%[:/#@]%_%g')
+# execute source analyzer (eventually load different environment for java)
+load_ols_env &>> $LOGDIR/fortify-scan.log
+SCA=$(which sourceanalyzer)
+SCAMAJORVERSION=$($SCA -version 2> /dev/null | grep -o -e "Fortify Static Code Analyzer [0-9]\{1,2\}" | grep -o -e "[0-9]\{1,2\}")
+
+# if the major version of Fortify is more recent that 17, use 4 cores for the analysis
+MTCOMMAND=""
+CORES=1
+if [ -n "$SCAMAJORVERSION" ] && [ "$SCAMAJORVERSION" -ge 17 ]; then
+  # make sure we use parallel analysis only if enough memory is available
+  # do not enable -mt at all, because otherwise the cores preset of Fortify would be used
+  if [ "$AVAILABLE_MEM" -ge 32000 ]; then
+    CORES=$(($AVAILABLE_MEM / 16000))
+    MTCOMMAND="-mt -Dcom.fortify.sca.ThreadCount=$CORES"
+  fi
+fi
+
+log "use sourceanalyzer with $CORES cores from $SCA ($(file $SCA))"
+measured_execution $TMP sourceanalyzer -b $FORTIFY_BUILD_ID \
+  -Dcom.fortify.WorkingDirectory=$DATADIR \
+  -Dcom.fortify.sca.ProjectRoot=$DATADIR \
+  -Dcom.fortify.sca.limiters.MaxIndirectResolutionsForCall=1024 \
+  -scan -verbose \
+  $MTCOMMAND \
+  -Xmx${AVAILABLE_MEM}M \
+  -f $LOGDIR/report.fpr -html-report 2>&1 | tee $LOGDIR/fortify-scan.log
+ANALYSIS_RESULT=$?
+# unload environment again
+unload_ols_env &>> $LOGDIR/fortify-scan.log
+log "fortify scan ended with $ANALYSIS_RESULT"
+log "  internal errors:"
+log "$(grep "^\[error\]:" $LOGDIR/fortify-scan.log 2> /dev/null)"
+
+# if no files have been there to be scanned, this is not an error but should
+# be forwarded
+if [ $ANALYSIS_RESULT -ne 0 ] && [ ! -f .sca.pid ]; then
+  log "warning: could not find analysis files. Have you compiled any files?"
+  ANALYSIS_RESULT=0
+  ANALYSIS_HAPPENED=
+fi
+
+# only have metrics if we actually scanned something
+# otherwise, a warning is printed above already
+if [ -n "$ANALYSIS_HAPPENED" ]; then
+	TIMEMETRICS=$(cat $TMP)
+	TIMESTAMP=$(( $(date +%s%N) / 1000000 ))
+	# collect number of all warnings
+	FINDINGS=$(grep "Rendering" $LOGDIR/fortify-scan.log 2>/dev/null | awk 'BEGIN {r="-"} {if( $2 +0 >= 0 ) r=$2} END {print r}')
+	if [ -z "$FINDINGS" ]
+	then
+		log "error: could not find reported number of Fortify findings"
+		ANALYSIS_RESULT=1
+	else
+		if [ "$FINDINGS" -gt 0 ]
+		then
+			ANALYSIS_RESULT=10
+		fi
+	fi
+	ANALYZEDFILES=$(grep "^Analyzing " "$LOGDIR"/fortify-scan.log 2>/dev/null | grep " source file(s)$" | awk 'BEGIN {r="-"} {if( $2 +0 >= 0 ) r=$2} END {print r}')
+	# make sure the date ends up in the log
+	LOGENTRY="$TIMESTAMP fortify $ORIGIN ALL ALL \
+		0 0 $ANALYSIS_RESULT $FINDINGS $ANALYZEDFILES $TIMEMETRICS"
+	echo "$LOGENTRY" >> $LOGDIR/fortify-scan.log
+fi
+
+exit $ANALYSIS_RESULT

--- a/configuration/backends/fortify/fortify-wrapper.sh
+++ b/configuration/backends/fortify/fortify-wrapper.sh
@@ -1,0 +1,300 @@
+#!/bin/bash
+#
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Control whether gcc has been called by Fortify, or some other tool
+
+#################### DO NOT MODIFY ##################
+
+# by default, all supported tools have not been found.
+NATIVE_GCC=/bin/false
+NATIVE_GPP=/bin/false
+NATIVE_CLANG=/bin/false
+NATIVE_CLANGPP=/bin/false
+TOOLPREFIX=
+TOOLSUFFIX=
+
+# path to the actual Fortify sourceanalyzer (SCA)
+NATIVE_SCA_PATH=
+FORTIFY_BUILD_ID=XXBUILDIDXX
+FORTIFY_OPTS=
+
+# arguments that should be added to the compiler (DO NOT TOUCH)
+GCCEXTRAARGUMENTS=
+
+# base file to check whether the current process has been called by the wrapper
+WRAPPERPIDFILE=/tmp/Fortify-wrapper-pid
+
+# location of this script
+SCRIPT=$(readlink -e "$0")
+SCRIPTDIR=$(dirname "$SCRIPT")
+LOG="$SCRIPTDIR/fortify-preprocess.log"
+
+# load the library
+source $SCRIPTDIR/../ols-library.sh || exit 1
+
+# forwarded options (options of the actual compiler call that should be
+# forwarded to the Fortify call)
+FORWARD_OPTIONS=( )
+FORTIFY_FILES=( )
+
+# preprocess all source files using the provided compiler $1
+function preprocess
+{
+  local compiler="$1"
+  local suffix="$2"
+  local i=0
+  local source_files=( )
+  local skip_next=0
+  local forward_next=0
+  local mode=c
+
+  shift 2
+
+  NEWARGV=( )
+  for a in "$@"
+  do
+    if [ $skip_next -eq 1 ]
+    then
+      skip_next=0
+      continue
+    fi
+    # handle part of split options that have to be forwarded
+    if [ $forward_next -eq 1 ]
+    then
+      forward_next=0
+      NEWARGV+=( "$a" )
+      FORWARD_OPTIONS+=( "$a" )
+      continue
+    fi
+    case "$a" in
+      -M|-MM) return 1 ;; # updates make rules only
+      -E) return 1 ;; # invoked as preprocessor only
+      -MMD | -MP | -MD) true ;;
+      -MT | -MF) skip_next=1 ;;
+      -c) true ;;
+      -S) mode=S ;;
+      -o) skip_next=1 ;;
+      -o*) true ;;
+      -Wp*) true ;;
+      # memorize options for call to fortify
+      -std*|-specs=*|-f*|-W*|-m*|-O*) NEWARGV+=( "$a" ); FORWARD_OPTIONS+=( "$a" );;
+      # handle split options that need to be forwarded
+      -specs) NEWARGV+=( "$a" ); FORWARD_OPTIONS+=( "$a" ) ; forward_next=1;;
+      # options that do not need to be treated specially
+      -*) NEWARGV+=( "$a" ) ;;
+      # collect files
+      *.c|*.cc|*.cpp|*.c++|*.C) source_files+=( "$a" ) ;;
+      *) NEWARGV+=( "$a" ) ;;
+    esac
+  done
+
+  FORWARD_OPTIONS+=( "-$mode" )
+
+  if [ ${#source_files[@]} -eq 0 ]
+  then
+    logwrapper "${TOOLPREFIX}"FORTIFY"${TOOLSUFFIX}" "no source files found, skip preprocessing"
+    return 1
+  fi
+  
+  logwrapper "${TOOLPREFIX}"FORTIFY"${TOOLSUFFIX}" "set command: set -- ${NEWARGV[@]} -E -o /dev/stdout"
+  set -- "${NEWARGV[@]}" -E -o /dev/stdout
+
+  for f in "${source_files[@]}"
+  do
+    rd=$(dirname "$f")
+    tmpfile=$(TMPDIR="$rd" mktemp -t fortify-preprocessedXXXXXX)
+    logwrapper "${TOOLPREFIX}"FORTIFY"${TOOLSUFFIX}" "create fortify source: $f to $tmpfile.$suffix"
+    "$compiler" "$@" "$f" $GCCEXTRAARGUMENTS > $tmpfile.$suffix
+    rm $tmpfile
+    FORTIFY_FILES+=( "$tmpfile.$suffix" )
+  done
+}
+
+#
+# start of the script
+#
+# redirect stdin to another file descriptor (here we picked 4), and close stdin afterwards
+# use this to pass stdin to the actual compiler call, and not to tools used before
+REDIRECT_STDIN=0
+if [ -t 0 ]
+then
+  exec 4<&0
+  exec 0<&-
+  REDIRECT_STDIN=1
+fi
+
+# use the binary name
+binary_name=$(basename $0)
+
+NATIVE_TOOL=
+case "$binary_name" in
+  "$TOOLPREFIX""cc""${TOOLSUFFIX}" | "$TOOLPREFIX""gcc""${TOOLSUFFIX}") NATIVE_TOOL=$NATIVE_GCC ;;
+  "$TOOLPREFIX""c++""${TOOLSUFFIX}" | "$TOOLPREFIX""g++""${TOOLSUFFIX}") NATIVE_TOOL=$NATIVE_GPP ;;
+  "$TOOLPREFIX""clang""${TOOLSUFFIX}") NATIVE_TOOL=$NATIVE_CLANG ;;
+  "$TOOLPREFIX""clang++""${TOOLSUFFIX}") NATIVE_TOOL=$NATIVE_CLANGPP ;;
+  *)
+    echo "error: Fortify wrapper has been called with an unknown tool name: $binary_name" 2>&1
+    exit 1
+    ;;
+esac
+
+if [ $NATIVE_TOOL = "/bin/true" ]
+then
+  NATIVE_TOOL=$(next_in_path $binary_name Fortify)
+fi
+
+# check whether some parent is the wrapper already
+called_by_wrapper $$
+parent_result=$?
+
+logwrapper "${TOOLPREFIX}"FORTIFY"${TOOLSUFFIX}" "called $binary_name, parent is Fortify wrapper: $parent_result"
+
+# if wrapper is not yet active in the calling tree
+if [ "$parent_result" != "1" ]
+then
+  # free the lock and the parent pid file in case something gets wrong
+  trap exit_handler EXIT
+
+  # tell that we are using the wrapper now with the current PID
+  touch "$WRAPPERPIDFILE$$"
+
+  # make sure we create our artificial compiler somewhere, where we can write
+  fortify_code=0
+  tmpdir=$(mktemp -d -t fortify.XXXXXX ) || fortify_code=1
+  tmpdir=$(readlink -f $tmpdir) || fortify_code=1
+
+  if [ "$fortify_code" -ne 0 ]
+  then
+    logwrapper "${TOOLPREFIX}"FORTIFY"${TOOLSUFFIX}" "creating temporary directory in $(pwd) falied, skip fortify compilation for call: $@"
+    exit $fortify_code
+  fi
+
+  logwrapper "${TOOLPREFIX}"FORTIFY"${TOOLSUFFIX}" "preprocessing with $binary_name using $NATIVE_TOOL to $tmpdir/"
+  # use the actual compiler binary
+  case "$binary_name" in
+    "$TOOLPREFIX""cc""${TOOLSUFFIX}" | "$TOOLPREFIX""gcc""${TOOLSUFFIX}" | \
+      "$TOOLPREFIX""clang""${TOOLSUFFIX}" )
+      # rename the currently used compiler to "gcc", such that Fortify can
+      # work with it
+      ln -s $NATIVE_TOOL $tmpdir/gcc
+      if preprocess "$NATIVE_TOOL" "c" "$@"
+      then
+        logwrapper "${TOOLPREFIX}"FORTIFY"${TOOLSUFFIX}" "run fortify analysis: "
+        logwrapper "${TOOLPREFIX}"FORTIFY"${TOOLSUFFIX}" "original command line: $binary_name $@"
+        logwrapper "${TOOLPREFIX}"FORTIFY"${TOOLSUFFIX}" "$NATIVE_SCA_PATH -b "$FORTIFY_BUILD_ID" $FORTIFY_OPTS $tmpdir/gcc ${FORTIFY_FILES[@]} ${FORWARD_OPTIONS[@]} $GCCEXTRAARGUMENTS"
+        # execute source analyzer (eventually load different environment for java)
+        load_ols_env &> $LOG
+        if [ $REDIRECT_STDIN -eq 1 ]
+        then
+          $NATIVE_SCA_PATH -b "$FORTIFY_BUILD_ID" -nc $FORTIFY_OPTS \
+            $tmpdir/gcc "${FORTIFY_FILES[@]}" "${FORWARD_OPTIONS[@]}" $GCCEXTRAARGUMENTS \
+            >  >(tee -a "$LOG") \
+            2> >(tee -a "$LOG" 1>&2)
+        else
+          $NATIVE_SCA_PATH -b "$FORTIFY_BUILD_ID" -nc $FORTIFY_OPTS \
+            $tmpdir/gcc "${FORTIFY_FILES[@]}" "${FORWARD_OPTIONS[@]}" $GCCEXTRAARGUMENTS
+        fi
+        fortify_code=$?
+        # unload environment again
+        unload_ols_env &> $LOG
+        logwrapper "${TOOLPREFIX}"FORTIFY"${TOOLSUFFIX}" "exit code $fortify_code"
+        for f in "${FORTIFY_FILES[@]}"
+        do
+          rm -f "$f" $(basename "${f/%.c/.o}")
+        done
+      else
+        logwrapper "${TOOLPREFIX}"FORTIFY "run fortify link-time analysis: "
+        logwrapper "${TOOLPREFIX}"FORTIFY "original command line: $binary_name $@"
+        logwrapper "${TOOLPREFIX}"FORTIFY "$NATIVE_SCA_PATH -b "$FORTIFY_BUILD_ID" $FORTIFY_OPTS $tmpdir/gcc $@ $GCCEXTRAARGUMENTS"
+        # execute source analyzer (eventually load different environment for java)
+        load_ols_env &> $LOG
+        if [ $REDIRECT_STDIN -eq 1 ]
+        then
+          $NATIVE_SCA_PATH -b "$FORTIFY_BUILD_ID" -nc $FORTIFY_OPTS \
+            $tmpdir/gcc "$@" $GCCEXTRAARGUMENTS \
+            >  >(tee -a "$LOG") \
+            2> >(tee -a "$LOG" 1>&2)
+        else
+          $NATIVE_SCA_PATH -b "$FORTIFY_BUILD_ID" -nc $FORTIFY_OPTS \
+            $tmpdir/gcc "$@" $GCCEXTRAARGUMENTS
+        fi
+        fortify_code=$?
+        # unload environment again
+        unload_ols_env &> $LOG
+        logwrapper "${TOOLPREFIX}"FORTIFY "exit code $fortify_code"
+      fi
+      ;;
+    "$TOOLPREFIX""c++""${TOOLSUFFIX}" | "$TOOLPREFIX""g++""${TOOLSUFFIX}" | "$TOOLPREFIX""clang++""${TOOLSUFFIX}" )
+      # rename the currently used compiler to "g++", such that Fortify can
+      # work with it
+      ln -s $NATIVE_TOOL $tmpdir/g++
+      if preprocess "$NATIVE_TOOL" "cpp" "$@"
+      then
+        logwrapper "${TOOLPREFIX}"FORTIFY"${TOOLSUFFIX}" "run fortify analysis: "
+        logwrapper "${TOOLPREFIX}"FORTIFY"${TOOLSUFFIX}" "$NATIVE_SCA_PATH -b "$FORTIFY_BUILD_ID" $FORTIFY_OPTS $tmpdir/g++ ${FORTIFY_FILES[@]} ${FORWARD_OPTIONS[@]} $GCCEXTRAARGUMENTS"
+        # execute source analyzer (eventually load different environment for java)
+        load_ols_env &> $LOG
+        if [ $REDIRECT_STDIN -eq 1 ]
+        then
+          $NATIVE_SCA_PATH -b "$FORTIFY_BUILD_ID" -nc $FORTIFY_OPTS \
+            $tmpdir/g++ "${FORTIFY_FILES[@]}" "${FORWARD_OPTIONS[@]}" $GCCEXTRAARGUMENTS \
+            >  >(tee -a "$LOG") \
+            2> >(tee -a "$LOG" 1>&2)
+        else
+          $NATIVE_SCA_PATH -b "$FORTIFY_BUILD_ID" -nc $FORTIFY_OPTS \
+            $tmpdir/g++ "${FORTIFY_FILES[@]}" "${FORWARD_OPTIONS[@]}" $GCCEXTRAARGUMENTS
+        fi
+        fortify_code=$?
+        # unload environment again
+        unload_ols_env &> $LOG
+        logwrapper "${TOOLPREFIX}"FORTIFY"${TOOLSUFFIX}" "exit code $fortify_code"
+        for f in "${FORTIFY_FILES[@]}"
+        do
+          rm -f "$f" $(basename "${f/%.cpp/.o}")
+        done
+      else
+        logwrapper "${TOOLPREFIX}"FORTIFY "run fortify link-time analysis: "
+        logwrapper "${TOOLPREFIX}"FORTIFY "$NATIVE_SCA_PATH -b "$FORTIFY_BUILD_ID" $FORTIFY_OPTS $tmpdir/g++ $@ $GCCEXTRAARGUMENTS"
+        # execute source analyzer (eventually load different environment for java)
+        load_ols_env &> $LOG
+        if [ $REDIRECT_STDIN -eq 1 ]
+        then
+          $NATIVE_SCA_PATH -b "$FORTIFY_BUILD_ID" -nc $FORTIFY_OPTS \
+            $tmpdir/g++ "$@" $GCCEXTRAARGUMENTS \
+            >  >(tee -a "$LOG") \
+            2> >(tee -a "$LOG" 1>&2)
+        else
+          $NATIVE_SCA_PATH -b "$FORTIFY_BUILD_ID" -nc $FORTIFY_OPTS \
+            $tmpdir/g++ "$@" $GCCEXTRAARGUMENTS
+        fi
+        fortify_code=$?
+        # unload environment again
+        unload_ols_env &> $LOG
+        logwrapper "${TOOLPREFIX}"FORTIFY "exit code $fortify_code"
+      fi
+      ;;
+    *)
+      echo "error: Fortify wrapper has been called with an unknown tool name: $binary_name" 2>&1
+      rm -r $tmpdir
+      exit 1
+      ;;
+  esac
+  rm -r $tmpdir
+  [ $fortify_code -eq 0 ] || exit $fortify_code
+fi
+
+logwrapper "${TOOLPREFIX}"FORTIFY"${TOOLSUFFIX}" "call native $NATIVE_TOOL $@"
+[ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+$NATIVE_TOOL "$@" $GCCEXTRAARGUMENTS

--- a/configuration/backends/fortify/summarize-fortify.py
+++ b/configuration/backends/fortify/summarize-fortify.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Parse the report.html of Fortify and create an ASCII summary
+
+import os
+import sys
+from subprocess import call
+from xml.etree import ElementTree
+
+# print usage
+if len(sys.argv) != 2:
+  print "usage summarizy-fortify.py LOGDIR"
+  sys.exit(1)
+
+# get directory where the logs are placed
+logdir=sys.argv[1]
+
+# strip this part of the directory information of
+workdirectory = os.getcwd() + '/'
+
+# get the fortify report; first make it valid XML
+filename=logdir+'/log/report.html'
+call(['perl', '-p', '-i', '-e', 's#<((img|meta) [^>]+)>#<$1/>#', filename])
+# make sure we can run this script multiple times on the same html file
+call(['perl', '-p', '-i', '-e', 's#//>#/>#', filename])
+
+# parse the html file and jump to the last table
+data=ElementTree.parse(filename).getroot()
+table=data.find('.//table')[-1]
+
+# iterate over all rows and print their content in a more useable format
+for data in table.iter('tr'):
+  # handle only the rows that contain results
+  if len(data) != 4:
+    continue
+  # extract file information, convert absolute path into relative one
+  location=data[2].find('a')
+  # header does not have <a ...>
+  if location is None:
+    continue
+  filename=location.get('href')
+  filename=filename.replace('file://','')
+  filename=filename.replace(workdirectory,'')
+  severity=data[3].text
+  if severity is None:
+    severity=data[3].find('span').text
+  # strip newline and space sequences
+  problem=data[0].text.replace('\n','').replace('\r','')
+  short=problem.replace('  ',' ')
+  while len(short) < len(problem):
+    problem=short
+    short=problem.replace('  ',' ')
+  column=ElementTree.tostring(data[2].findall("*")[0]).split(':')[2]
+  printstring = filename + ':' + column.strip() + ', ' + \
+    severity.strip() + ', ' + \
+    problem
+  if data[1].text is not None:
+    printstring = printstring + ', ' + data[1].text
+  print printstring

--- a/configuration/backends/plain/plain-evaluate.sh
+++ b/configuration/backends/plain/plain-evaluate.sh
@@ -1,0 +1,27 @@
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Evaluate the plain wrapper run
+
+# Evaluate and return non-zero in case of failure
+function evaluate_plain
+{
+  local -r RESULTS_DIR="$WORKINGDIR/plain"
+  local -r CALLLOG="$RESULTS_DIR/calls.json"
+  local -r REPLAYLOG="$RESULTS_DIR/replay.log"
+
+  echo "found $(cat $REPLAYLOG | wc -l) calls to the compiler"
+  [ ! -f "$REPLAYLOG" ] || echo "calls to replay can be found in: $REPLAYLOG"
+  [ ! -f "$CALLLOG" ] || echo "more structured calls can be found in: $CALLLOG"
+  return 0
+}

--- a/configuration/backends/plain/plain-hook-install.sh
+++ b/configuration/backends/plain/plain-hook-install.sh
@@ -1,0 +1,82 @@
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Setup the plain wrapper to log all compiler calls, and extract some relevant
+# information to make working with large code bases simpler.
+#
+# This file is meant to be sourced by the setup script that installs all
+# selected wrapper hooks. Hence, it contains variables that are not defined in
+# this script.
+
+# install the hook.
+inject_plain()
+{
+  # we will place the plain wrapper here
+  local -r TOOL="plain"
+  local -r INSTALL_DIR="$GOTO_GCC_WRAPPER_INSTALL_DIR/$TOOL"
+
+  # use source dir to be able to copy the correct wrapper script
+  local -r HOOK_SRC_DIR="$( dirname "${BASH_SOURCE[0]}" )"
+
+  # install wrapper
+  mkdir -p "$INSTALL_DIR"
+  for SUFFIX in "" $TOOLSUFFIX
+  do
+  for PREFIX in "" $TOOLPREFIX
+  do
+    # exclude the case where both prefix and suffix are active
+    [ -z "$SUFFIX" ] || [ -z "$PREFIX" ] || continue
+
+    # we will point all calls to relevant compilers to the same wrapper
+    local TARGET_GCC="$INSTALL_DIR/${PREFIX}gcc${SUFFIX}"
+    cp "$HOOK_SRC_DIR/$TOOL-wrapper.sh" "$TARGET_GCC"
+
+    # add extra arguments to wrapper script
+    if [ ! -z "$GCC_WRAPPER_EXTRAARGUMENTS" ]
+    then
+        perl -p -i -e "s:^GCCEXTRAARGUMENTS=:GCCEXTRAARGUMENTS=\"$GCC_WRAPPER_EXTRAARGUMENTS\":" "$TARGET_GCC"
+    fi
+
+    # tell the wrapper about the location of the actual compilers
+    perl -p -i -e "s:TOOLPREFIX=:TOOLPREFIX=$PREFIX:" "$TARGET_GCC"
+    perl -p -i -e "s:TOOLSUFFIX=:TOOLSUFFIX=$SUFFIX:" "$TARGET_GCC"
+
+    # make sure we use the same lock directory name everywhere
+    perl -p -i -e "s:XX/tmp/plain-wrapper-lockXX:$INSTALL_DIR/wrapper-lock:" "$TARGET_GCC"
+
+    # tell the wrapper from where install has been called
+    perl -p -i -e "s:CALL_DIR=:CALL_DIR=$(readlink -e $(pwd))/:" "$TARGET_GCC"
+
+    for t in gcc g++ clang clang++
+    do
+      T=$(echo $t | tr '[a-z]+' '[A-Z]P')
+      p=$(find_native "$PREFIX"$t"$SUFFIX")
+      perl -p -i -e "s:^NATIVE_$T=.*:NATIVE_$T=$p:" "$TARGET_GCC"
+    done
+
+    # make the other compiler use the fortify wrapper
+    for TARGET_COMPILER in g++ clang clang++ cc c++
+    do
+      # might fail, because if check-setup.sh is used, the directory is already
+      # there, as well as the links
+      cp "$TARGET_GCC" "$INSTALL_DIR/${PREFIX}${TARGET_COMPILER}${SUFFIX}"
+    done
+  done
+  done
+
+  # after using all previous tool locations to setup the wrapper script,
+  # activate the wrapper script
+  export PATH="$INSTALL_DIR":$PATH
+
+  return 0
+}

--- a/configuration/backends/plain/plain-wrapper.sh
+++ b/configuration/backends/plain/plain-wrapper.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+#
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Wrap all compiler calls so that we can
+#  * log the call with its options and directory
+#  * extend the call by further arguments that are added at the end of the call
+
+#################### DO NOT MODIFY ##################
+
+# by default, all supported tools have not been found.
+NATIVE_GCC=/bin/false
+NATIVE_GPP=/bin/false
+NATIVE_CLANG=/bin/false
+NATIVE_CLANGPP=/bin/false
+
+TOOLPREFIX=
+TOOLSUFFIX=
+
+# directory name used to lock concurrent access
+LOCKDIR=XX/tmp/plain-wrapper-lockXX
+TRAPDIR=
+
+# arguments that should be added to the compiler (DO NOT TOUCH)
+GCCEXTRAARGUMENTS=
+
+# directory from which the tool has been called for build
+CALL_DIR=
+
+# base file to check whether the current process has been called by the wrapper
+WRAPPERPIDFILE=/tmp/plain-wrapper-pid
+
+# location of this script (after being installed for the specific build call)
+SCRIPT=$(readlink -e "$0")
+SCRIPTDIR=$(dirname "$SCRIPT")
+LOG="$SCRIPTDIR/plain-preprocess.log"
+CALLLOG="$SCRIPTDIR/calls.json"
+REPLAYLOG="$SCRIPTDIR/replay.log"
+FAILLOG="$SCRIPTDIR/failed_calls.log"
+
+# load the library
+source $SCRIPTDIR/../ols-library.sh || exit 1
+
+# forwarded options (options of the actual compiler call that should be
+# forwarded to the define expansion call)
+FORWARD_OPTIONS=( )
+
+# this function returns if it has been able to create "$LOCKDIR"
+function lock_plain
+{
+  # grep lock and write json log entry
+  while ! mkdir "$LOCKDIR" 2> /dev/null
+  do
+    # busy waiting, not putting too much load on the file system, but not waiting too long
+    sleep 0.05
+  done
+
+  # tell trap about the directory only after we actually hold the lock
+  TRAPDIR="$LOCKDIR"
+}
+
+function unlock_plain
+{
+  # free the lock again
+  rm -rf "$TRAPDIR"
+  TRAPDIR=
+}
+
+# process compiler call with compiler $1 and suffix $2
+function log_compiler_call
+{
+  local compiler="$1"
+  local suffix="$2"
+  local i=0
+  local SOURCE_FILES=( )
+  local skip_next=0
+  local use_next_include=0
+  local use_next_macro=0
+
+  shift 2
+
+  NEWARGV=( )
+  INCLUDES=( )
+  MACROS=( )
+
+  for a in "$@"
+  do
+    if [ $skip_next -eq 1 ]
+    then
+      skip_next=0
+      continue
+    fi
+    # handle part of split options that have to be forwarded
+    if [ $use_next_include -eq 1 ]
+    then
+      use_next_include=0
+      INCLUDES+=( "$a" )
+      continue
+    fi
+    if [ $use_next_macro -eq 1 ]
+    then
+      use_next_macro=0
+      MACROS+=( "$a" )
+      continue
+    fi
+
+    # we are only interested in "-I" and "-D"
+    case "$a" in
+      -M|-MM) return 1 ;; # updates make rules only
+      -MMD | -MP | -MD) true ;;
+      -MT | -MF) skip_next=1 ;;
+      -c) true ;;
+      -S) true ;;
+      -o) skip_next=1 ;;
+      -o*) true ;;
+      -Wp*) true ;;
+      # collect -D*, -U* and -I* without space
+      -D* | -U* ) MACROS+=( "$a" );; 
+      -I* ) INCLUDES+=( "$a" );;
+      # handle split options that need to be forwarded
+      -D | -U ) MACROS+=( "$a" ); use_next_macro=1;;
+      -I ) INCLUDES+=( "$a" ); use_next_include=1;;
+      # options that do not need to be treated specially
+      -*) true ;;
+      # collect files
+      *.c|*.cc|*.cpp|*.c++|*.C) SOURCE_FILES+=( "$a" ) ;;
+      # we are not interested in object files
+      *.o) true ;;
+      *) NEWARGV+=( "$a" ) ;;
+    esac
+  done
+
+  # use the directory relative to the call, in case there is a common prefix
+  DIR=$(readlink -e $(pwd))
+  [ -z "$CALL_DIR" ] || DIR=${DIR#$CALL_DIR}
+  
+  # create JSON data to be printed into log file
+  CALL=$(for f in "$@"; do printf "\"%s\" " "$f"; done; [ -z "$GCCEXTRAARGUMENTS" ] || printf "%s" "$GCCEXTRAARGUMENTS" )
+  [ -z "$SOURCE_FILES" ] || FULL_SOURCE_FILES=$(for f in "$SOURCE_FILES"; do ff="$(readlink -e $f)"; [ -z "$CALL_DIR" ] || ff=${ff#$CALL_DIR}  printf "\"%s\" " "$(readlink -e $ff)"; done)
+  [ -z "$SOURCE_FILES" ] || SOURCE_FILES=$(for f in "$SOURCE_FILES"; do printf "\"%s\" " "$f"; done)
+  [ -z "$INCLUDES" ] || INCLUDES=$(for f in "$INCLUDES"; do printf "\"%s\" " "$f"; done)
+  MACROS=$(for f in "$MACROS"; do printf "\"%s\" " "$f"; done)
+
+  declare -a CMD=$@
+
+  # lock, and create the file entries
+  lock_plain
+  cat << EOF  >> "$CALLLOG"
+{
+	'call' : '$compiler $CALL'
+        'dir' : '$DIR'
+	'source' : '$SOURCE_FILES'
+	'macros' : '$MACROS'
+	'include' : '$INCLUDES'
+}
+EOF
+
+  printf "cd %s; %s %s %s\n" "$(pwd)" "$compiler" "${CMD[@]}" "$GCCEXTRAARGUMENTS" >> "$REPLAYLOG"
+
+  unlock_plain
+}
+
+#
+# start of the script
+#
+# redirect stdin to another file descriptor (here we picked 4), and close stdin afterwards
+# use this to pass stdin to the actual compiler call, and not to tools used before
+REDIRECT_STDIN=0
+if [ -t 0 ]
+then
+  exec 4<&0
+  exec 0<&-
+  REDIRECT_STDIN=1
+fi
+
+# the directory, in which the lock directory should be created, has to exist
+# otherwise the wrapper is broken (and the locking mkdir would block forever)
+LOCK_PARENT_DIR="$(dirname $LOCKDIR)"
+if [ ! -d "$LOCK_PARENT_DIR" ]
+then
+  echo "error: goto-gcc wrapper is broken" >&2
+  exit 1
+fi
+
+# use the binary name
+binary_name=$(basename $0)
+
+NATIVE_TOOL=
+case "$binary_name" in
+  "$TOOLPREFIX""cc""$TOOLSUFFIX" | "$TOOLPREFIX""gcc""$TOOLSUFFIX") NATIVE_TOOL=$NATIVE_GCC ;;
+  "$TOOLPREFIX""c++""$TOOLSUFFIX" | "$TOOLPREFIX""g++""$TOOLSUFFIX") NATIVE_TOOL=$NATIVE_GPP ;;
+  "$TOOLPREFIX""clang""$TOOLSUFFIX") NATIVE_TOOL=$NATIVE_CLANG ;;
+  "$TOOLPREFIX""clang++""$TOOLSUFFIX") NATIVE_TOOL=$NATIVE_CLANGPP ;;
+  *)
+    logwrapper "${TOOLPREFIX}"PLAIN"${TOOLSUFFIX}"  "error: plain wrapper has been called with an unknown tool name: $binary_name"
+    exit 1
+    ;;
+esac
+
+if [ $NATIVE_TOOL = "/bin/true" ]
+then
+  NATIVE_TOOL=$(next_in_path $binary_name plain)
+fi
+
+# check whether some parent is the wrapper already
+called_by_wrapper $$
+parent_result=$?
+logwrapper "${TOOLPREFIX}"PLAIN"${TOOLSUFFIX}" "called $binary_name with $*, parent is plain wrapper: $parent_result"
+
+# if wrapper is not yet active in the calling tree
+if [ "$parent_result" != "1" ]
+then
+  # free the lock and the parent pid file in case something gets wrong
+  trap exit_handler EXIT
+
+  # tell that we are using the wrapper now with the current PID
+  touch "$WRAPPERPIDFILE$$"
+
+  logwrapper "${TOOLPREFIX}"PLAIN"${TOOLSUFFIX}" "processing with $binary_name using $NATIVE_TOOL"
+  # use the actual compiler binary
+  case "$binary_name" in
+    "$TOOLPREFIX""cc""$TOOLSUFFIX" | "$TOOLPREFIX""gcc""$TOOLSUFFIX" | \
+      "$TOOLPREFIX""clang" )
+      log_compiler_call "$NATIVE_TOOL" "c" "$@"
+      ;;
+    "$TOOLPREFIX""c++""$TOOLSUFFIX" | "$TOOLPREFIX""g++""$TOOLSUFFIX" | "$TOOLPREFIX""clang++""$TOOLSUFFIX" )
+      log_compiler_call "$NATIVE_TOOL" "cpp" "$@"
+      ;;
+    *)
+      logwrapper "${TOOLPREFIX}"PLAIN"${TOOLSUFFIX}"  "error: plain wrapper has been called with an unknown tool name: $binary_name"
+      exit 1
+      ;;
+  esac
+fi
+
+STATUS=0
+logwrapper "${TOOLPREFIX}"PLAIN"${TOOLSUFFIX}" "call native $NATIVE_TOOL $@"
+[ $REDIRECT_STDIN -ne 1 ] || exec 0<&4 4<&-
+$NATIVE_TOOL "$@" $GCCEXTRAARGUMENTS || STATUS=$?
+
+# log failed calls
+if [ "$STATUS" -ne 0 ]
+then
+  lock_plain
+  echo "exit with $STATUS: cd $(pwd); $NATIVE_TOOL $@ $GCCEXTRAARGUMENTS" >> "$FAILLOG"
+  unlock_plain
+fi
+
+exit $STATUS

--- a/configuration/bin/one-line-scan
+++ b/configuration/bin/one-line-scan
@@ -1,0 +1,1 @@
+../one-line-scan

--- a/configuration/doc/EXAMPLES.md
+++ b/configuration/doc/EXAMPLES.md
@@ -1,0 +1,51 @@
+# Examples
+
+This file demonstrates how one-line-scan can be used with its various backends.
+
+## Getting Started
+
+The tool prints usage information is executed without any parameters.
+
+ one-line-scan
+
+When using the default options on a project, the project will be compiled for
+analysis with CBMC or other tools of the CPROVER tools suite, and a default
+analysis will be executed:
+
+ one-line-scan -- make
+
+To disable analysis, which might be expensive in case of CPROVER, add the
+--no-analysis flag:
+
+ one-line-scan --no-analysis -- make
+
+For using any other backend, make sure you disable the goto-cc backend with the
+--no-gotocc parameter.
+
+To store log files and results in another directory, the -o flag can be used:
+
+ one-line-scan --no-analysis -o OLS -- make
+
+## Plain Backend - Spot Failing Compiler Calls
+
+A use case of the plain backend is to trace failing compiler calls on a project
+that has many compiler calls and is typically compiled with several jobs. The
+plain wrapper records failing compiler calls, that can be investigated
+afterwards without rerunning sequential compilation again:
+
+ one-line-scan --plain --no-gotocc -o PLAIN -- make -j $(nproc)
+
+To display the failing calls, including the working directory where the call was
+actually issued, have a look into the failed_calls.log file:
+
+ cat PLAIN/plain/failed_calls.log
+
+## Fortify Backend
+
+To analyze C/C++ projects with Fortify, the used compiler has to be gcc.
+However, some projects use different compiler names instead. The fortify wrapper
+takes care of the renaming, so that for example the compiler
+x86_64-unknown-linux-gcc can be used, as well as other cross-compilers. To use
+such a compiler, the --prefix parameter can be added.
+
+ one-line-scan --fortify --no-gotocc --prefix x86_64-unknown-linux- -- make

--- a/configuration/doc/README.md
+++ b/configuration/doc/README.md
@@ -1,0 +1,37 @@
+## One Line Scan
+
+With this tool, projects can be compiled easily for fuzzing with AFL or for
+static code analysis with tools like CBMC. One-line-scan hooks into the
+compilation process and wraps calls to the compiler with other compilers.
+Besides the compilation wrappers, one-line-scan ships with basic analysis jobs,
+that allow to analyze a project right after compilation with the following
+tools: AFL, cppcheck, CBMC, Fortify.
+
+## Usage
+
+### Install
+
+As One Line Scan is a scripted tool, the project can be checked out of the
+repository, and used from there. However, it is recommended to make it available
+on the PATH for simpler consumption.
+
+To get the code, use the following command
+
+ git clone https://github.com/awslabs/one-line-scan.git
+
+### Getting Started
+
+One Line Scan has several back ends. The default backend is the goto-cc wrapper,
+which compiles a project for tools of the CPROVER suite. The simplest one is the
+plain backend, which only tracks calls to the compiler, but does not act upon
+them. An example invocation for the plain backend and a project whose build
+command is "make" would be:
+
+ one-line-scan --plain --no-gotocc -- make
+
+More invocations of one-line-scan are presented in the file
+configuration/doc/EXAMPLES.md
+
+## License
+
+This library is licensed under the Apache 2.0 License.

--- a/configuration/inject-gcc-wrapper/check-setup.sh
+++ b/configuration/inject-gcc-wrapper/check-setup.sh
@@ -1,0 +1,42 @@
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Checks whether setting up the gcc wrapper would work
+#
+#
+# Usage: check-setup.sh [OPTIONS]   ... to make the variables visible in the calling shell
+#           OPTIONS ... options to be used for the test. They are forwarded to setup.sh
+#
+
+echo "test setting up the gcc-wrapper ..."
+PREVIOUS=$(which gcc)
+
+# use "original" setup script, and pass the parameter for the directory
+SOURCE_DIR="$( dirname "${BASH_SOURCE[0]}" )"
+source "$SOURCE_DIR"/setup.sh "$@"
+
+AFTER=$(which gcc)
+
+failed=1
+if [ ! "$PREVIOUS" == "$AFTER" ] && [ -n "$AFTER" ]
+then
+  failed=0
+  # in case of success, remove the wrapper again (keep directory)
+  if [ -n "$SOURCE_DIR" ]
+  then
+    source "$SOURCE_DIR"/remove-wrapper.sh "--keep-dir"
+  fi
+fi
+echo "Test failed: $failed"
+
+exit $failed

--- a/configuration/inject-gcc-wrapper/ols-library.sh
+++ b/configuration/inject-gcc-wrapper/ols-library.sh
@@ -1,0 +1,158 @@
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Library that offers functionality used by backend wrappers
+
+# locate the wrapped binary on the PATH
+next_in_path ()
+{
+  local cmd=$1
+  local inst_path=$(dirname $SCRIPT)
+  local subdir=$2
+  if [ -n "$subdir" ]
+  then
+    inst_path=${inst_path%/$subdir}
+  fi
+  ifs=$IFS
+  IFS=:
+  state=0
+  for p in $PATH
+  do
+    if [ "$SCRIPT" = "$(readlink -e $p/$cmd)" ]
+    then
+      state=1
+    elif [ $state -eq 0 ] && [ -z "$subdir" -o "$inst_path" != "$(readlink -e $p)" ] && [ -x $p/$cmd ]
+    then
+      IFS=$ifs
+      echo $p/$cmd
+      return 0
+    elif [ $state -eq 1 ] && [ -x $p/$cmd ]
+    then
+      IFS=$ifs
+      echo $p/$cmd
+      return 0
+    fi
+  done
+
+  IFS=$ifs
+  if [ $state -eq 0 ]
+  then
+    echo "error: $SCRIPT not found in PATH" 1>&2
+    echo "/bin/false"
+  else
+    echo "error: $cmd not found in PATH" 1>&2
+    echo "/bin/false"
+  fi
+  return 1
+}
+
+# explicit exit handler function
+exit_handler ()
+{
+   rm -rf "$TRAPDIR"
+   rm -f "$WRAPPERPIDFILE$$"
+}
+
+# get parent id of pid that is handed in
+function called_by_wrapper
+{
+  parent=$(ps -p $1 -o ppid=  | tr -d " " )
+  # reached calling root
+  if [ "$parent" -le "1" ] || [ -z "$parent" ]
+  then
+    return 0
+  fi
+  # wrapper pid file exists with given PID?
+  if [ -f "$WRAPPERPIDFILE$parent" ]
+  then
+    return 1
+  fi
+  # else call function with pid of parent
+  called_by_wrapper $parent
+}
+
+# portable implementation of realpath
+function full_path
+{
+  local f="$1"
+  if readlink -f / >/dev/null 2>&1
+  then
+    readlink -f $f
+  else
+    if [[ "$f" =~ ^/ ]]
+    then
+      echo "$f"
+    else
+      echo "$(pwd -P)/""$f"
+    fi
+  fi
+}
+
+# print/store logging output
+function logwrapper
+{
+  local name=$1
+  shift
+  echo "[$name-WRAPPER,$$] $@" >> $LOG #1>&2
+  return 0
+}
+
+# load content of all OLS_X variables into X, and store a backup of X
+function load_ols_env
+{
+  # do not allow to call this method twice
+  [ -z "$LOADED_OLS_ENV" ] || return
+  # iterate over all variables in env that start with OLS_
+  for SP_VAR in $(env | grep ^OLS_ | cut -f1 -d=); do
+    # get the part behind the "=" char
+    local SP_VAL="${SP_VAR%=*}"
+    # cut off OLS prefix and get the part behind the "=" char
+    local VAR="${SP_VAR##OLS_}"
+    VAR="${VAR%=*}"
+    # backup the previous value of the variable
+    [ -n "${!VAR}" ] && export BACKUP_OLS_$VAR="${!VAR}"
+    # set the new value of the variable
+    echo "overwrite environment variable: $VAR=${!SP_VAL}" 1>&2
+    export $VAR="${!SP_VAL}"
+  done
+  # memorize that we called this method already
+  export LOADED_OLS_ENV=t
+}
+
+# restore (or unset) content of all variables X for which a OLS_X exists
+function unload_ols_env
+{
+  # do not unload, if no environment has been loaded
+  [ -n "$LOADED_OLS_ENV" ] || return
+  # iterate over all variables in env that start with OLS_
+  for SP_VAR in $(env | grep ^OLS_ | cut -f1 -d=); do
+    # cut off OLS prefix and get the part behind the "=" char
+    local VAR="${SP_VAR##OLS_}"
+    VAR="${VAR%=*}"
+    local BACKUP_VAR=BACKUP_OLS_$VAR
+    # restore backup
+    if [ -n "${!BACKUP_VAR}" ]
+    then
+      export $VAR="${!BACKUP_VAR}"
+      echo "restore variable $VAR=${!VAR}" 1>&2
+    else
+      # if there has not been an initial value, make sure we remove the value
+      echo "unset variable $VAR" 1>&2
+      unset $VAR
+    fi
+    # remove the backup variable as well
+    unset "$BACKUP_VAR"
+  done
+  # memorize that we cleaned up the environment again
+  unset LOADED_OLS_ENV
+}

--- a/configuration/inject-gcc-wrapper/remove-wrapper.sh
+++ b/configuration/inject-gcc-wrapper/remove-wrapper.sh
@@ -1,0 +1,79 @@
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Remove the goto-gcc wrapper for cc, gcc and ld from the PATH environment
+#
+# Usage: source remove-wrapper.sh   ... make the variables visible in the calling shell
+#
+# options: --keep-dir  does not remove the directory where the wrapper files were stored
+#
+
+# set defaults
+keepdirectory=
+
+# parse arguments
+while [ ! -z "$*" ]
+do
+	case $1 in
+	--keep-dir) 	keepdirectory=t;;
+	--no-keep-dir) 	keepdirectory=;;
+	*)
+		echo "warning: unknown parameter: $1"
+	esac
+	shift
+done
+
+# restore previous path environment variable
+if [ -n "$PRE_GOTO_GCC_WRAPPER_PATH" ]
+then
+  export PATH="$PRE_GOTO_GCC_WRAPPER_PATH"
+  PRE_GOTO_GCC_WRAPPER_PATH=""
+
+  # delete all the directories that have been created?
+  if [ -z "$keepdirectory" ] && [ -n "$FULLDIRECTORY" ]
+  then
+    rm -f "$FULLDIRECTORY"/{binaries.list,build.log,environmentInfo.txt,wrapper-log.txt,libraries.list}
+  fi
+  if [ -n "$GOTO_GCC_WRAPPER_INSTALL_DIR" ]
+  then
+    # the directory contains the lock as well
+    if [ -z "$keepdirectory" ] || [ "x$NESTED" = "xt" ]
+    then
+      rm -rf "$GOTO_GCC_WRAPPER_INSTALL_DIR/AFL"
+      rm -rf "$GOTO_GCC_WRAPPER_INSTALL_DIR/plain"
+      rm -rf "$GOTO_GCC_WRAPPER_INSTALL_DIR/cppcheck"
+      rm -rf "$GOTO_GCC_WRAPPER_INSTALL_DIR/Fortify"
+      rm -f "$GOTO_GCC_WRAPPER_INSTALL_DIR"/ols-library.sh
+      for PREFIX in "" $TOOLPREFIX
+      do
+        for t in gcc bcc as as86 g++ clang clang++ ld ar cc c++ objcopy
+        do
+          rm -f "$GOTO_GCC_WRAPPER_INSTALL_DIR"/$PREFIX$t
+        done
+      done
+      rm -f "$GOTO_GCC_WRAPPER_INSTALL_DIR"/make
+      rm -f "$GOTO_GCC_WRAPPER_INSTALL_DIR"/cflags
+
+      if ! rmdir -p "$GOTO_GCC_WRAPPER_INSTALL_DIR" 2>/dev/null
+      then
+        echo "warning: wrapper installation directory $GOTO_GCC_WRAPPER_INSTALL_DIR not empty" >&2
+      fi
+    fi
+    # clear the variable
+    GOTO_GCC_WRAPPER_INSTALL_DIR=""
+  fi
+
+  # do not delete /tmp/goto-gcc-wrapper-pid*, as those might be created by other SHELLS running in parallel
+else
+  echo "warning: did not find wrapper environment" >&2
+fi

--- a/configuration/inject-gcc-wrapper/setup.sh
+++ b/configuration/inject-gcc-wrapper/setup.sh
@@ -1,0 +1,393 @@
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Sets up the goto-gcc wrapper, currently replaces cc, gcc and ld
+#
+# create a (temporary) directory with the necessary tools
+# adds this directory to the PATH environment
+#
+# usage: source setup.sh [options]   ... to make the variables visible in the calling shell
+#           --target DIR       ... if specified, the directory DIR will be created and used for the wrapper
+#           --origin STR       ... source origin to identify the project
+#           --extra  ARG       ... add ARG to end of the gcc command line, can be specified multiple times
+#           --no-link / --link ... enforce goto-ld for linking (otherwise, fallback on native linker in case of failure)
+#           --keep-going       ... replace the make command with a command that adds the parameter -k
+#           --afl              ... wrap AFL compilers
+#           --fortify          ... run Fortify sourceanalyzer
+#           -j N               ... allow N compile commands to be executed in parallel (at least 2)
+#           --trunc            ... delete binary/library lists from directory, try to reuse existing directory
+#           --re-use           ... try to reuse existing directory
+#           --forward SRC DST  ... install a tool on the PATH with name SRC that actually would run DST (DST must exist on the PATH already)
+#           --prefix PRE       ... prefix for gcc, ld and ar (to be replaced by goto-gcc) , e.g. x86_64-linux-gnu-
+#           --suffix SUF       ... suffix for gcc, ld and ar (to be replaced by goto-gcc) , e.g. -7
+#           --include-warnings ... test each source file for redundant #include statements
+#           --nested           ... delay gcc wrapper configuration to handle paths of nested builds
+#
+# uninstall wrapper:
+#
+#        source remove-wrapper.sh
+#
+# do not return with first non-zero exit of a prorgamm call, as this would terminate the calling shell
+# set -e
+
+GCC_WRAPPER_EXTRAARGUMENTS=
+TARGET_DIRECTORY=
+GOTO_GCC_WRAPPER_ENFORCE_GOTO_LINKING=
+KEEP_GOING_IN_MAKE=
+WRAP_AFL=
+WRAP_CPPCHECK=
+WRAP_FORTIFY=
+WRAP_GOTOCC=1
+WRAP_PLAIN=
+NUM_LOCKS=2
+USE_EXISTING_DIR=
+FORWARDS=()
+TOOLPREFIX=
+TOOLSUFFIX=
+ORIGIN="one-line-scan"
+INCLUDE_WARNINGS=
+NESTED=
+
+# parse arguments
+parse_arguments ()
+{
+  while [ $# -gt 0 ]
+  do
+    case $1 in
+    --extra)      GCC_WRAPPER_EXTRAARGUMENTS="$GCC_WRAPPER_EXTRAARGUMENTS $2"; shift;;
+    --target)     TARGET_DIRECTORY="$2"        ; shift;;
+    --afl)        WRAP_AFL=t;;
+    --cppcheck)   WRAP_CPPCHECK=t;;
+    --fortify)    WRAP_FORTIFY=t;;
+    --no-gotocc)  WRAP_GOTOCC=;;
+    --plain)      WRAP_PLAIN=t;;
+    --link)       GOTO_GCC_WRAPPER_ENFORCE_GOTO_LINKING=t ;;
+    --no-link)    GOTO_GCC_WRAPPER_ENFORCE_GOTO_LINKING=  ;;
+    --keep-going) KEEP_GOING_IN_MAKE=t;;
+    --trunc)      USE_EXISTING_DIR=trunc;;
+                  # set a value different than trunc, the rest of the script checks only for "trunc" or "any other value"
+    --re-use)     USE_EXISTING_DIR=reuse;;
+    -j)           if [ $2 -ge 2 ]
+                  then
+                    NUM_LOCKS=$2
+                    shift
+                  else
+                    echo "warning: specified -j without an number, will not change value"
+                  fi
+                  ;;
+    --forward)    if [ -n "$2" ] && [ -n "$3" ]
+                  then
+                    FORWARDS+=("$2")
+                    FORWARDS+=("$3")
+                    shift 2
+                  else
+                    echo "error: forward is called without two following arguments - abort"
+                    echo "<$1> <$2> <$3>"
+                    return 1
+                  fi;;
+    --prefix)     TOOLPREFIX+=" $2"; shift;;
+    --suffix)     TOOLSUFFIX+=" $2"; shift;;
+    --origin)     ORIGIN=$2; shift;;
+    --include-warnings) INCLUDE_WARNINGS=t ;;
+    --nested)     NESTED=t
+                  TOOLPREFIX+=" x86_64-unknown-linux-gnu-";;
+    *)            echo "warning: unknown parameter $1" ;;
+    esac
+    shift
+  done
+
+  return 0
+}
+
+# check whether we already have an active wrapper and warn the user, but do not delete the other wrapper
+if [ -n "$GOTO_GCC_WRAPPER_INSTALL_DIR" ]
+then
+    echo "warning: found a wrapper already at $GOTO_GCC_WRAPPER_INSTALL_DIR"
+fi
+
+# use source dir to be able to copy the correct wrapper script
+SOURCE_DIR="$( dirname "${BASH_SOURCE[0]}" )"
+
+#
+# load compilers, allow a prefix and a suffix
+#
+load_compilers()
+{
+  local PREFIX="$1"
+  local SUFFIX="$2"
+
+  # find current versions of the used tools, fall back if tools do not exist
+  if [ -z "$PREFIX" ] || [ -z "$SUFFIX" ]
+  then
+    # in case either prefix or suffix are empty, drop the other and fall back to the original tool
+    GOTO_GCC_NATIVE_COMPILER="$(which "$PREFIX"gcc"$SUFFIX")"
+    [ -n "$GOTO_GCC_NATIVE_COMPILER" ] || GOTO_GCC_NATIVE_COMPILER="$(which gcc)"
+
+    GOTO_GCC_NATIVE_LINKER="$(which "$PREFIX"ld"$SUFFIX")"
+    [ -n "$GOTO_GCC_NATIVE_LINKER" ] || GOTO_GCC_NATIVE_LINKER="$(which ld)"
+
+    GOTO_GCC_NATIVE_AR="$(which "$PREFIX"ar"$SUFFIX")"
+    [ -n "$GOTO_GCC_NATIVE_AR" ] || GOTO_GCC_NATIVE_AR="$(which ar)"
+  else
+    # this case is defined to drop the suffix, and if still fails drop the prefix as well
+    GOTO_GCC_NATIVE_COMPILER="$(which "$PREFIX"gcc"$SUFFIX")"
+    [ -n "$GOTO_GCC_NATIVE_COMPILER" ] || GOTO_GCC_NATIVE_COMPILER="$(which "$PREFIX"gcc)"
+    [ -n "$GOTO_GCC_NATIVE_COMPILER" ] || GOTO_GCC_NATIVE_COMPILER="$(which gcc)"
+
+    GOTO_GCC_NATIVE_LINKER="$(which "$PREFIX"ld"$SUFFIX")"
+    [ -n "$GOTO_GCC_NATIVE_LINKER" ] || GOTO_GCC_NATIVE_LINKER="$(which "$PREFIX"ld)"
+    [ -n "$GOTO_GCC_NATIVE_LINKER" ] || GOTO_GCC_NATIVE_LINKER="$(which ld)"
+
+    GOTO_GCC_NATIVE_AR="$(which "$PREFIX"ar"$SUFFIX")"
+    [ -n "$GOTO_GCC_NATIVE_AR" ] || GOTO_GCC_NATIVE_AR="$(which "$PREFIX"ar)"
+    [ -n "$GOTO_GCC_NATIVE_AR" ] || GOTO_GCC_NATIVE_AR="$(which ar)"
+  fi
+
+  # return success
+  [ -x $GOTO_GCC_NATIVE_COMPILER ] && [ -x $GOTO_GCC_NATIVE_LINKER ] && [ -x $GOTO_GCC_NATIVE_AR ] && return 0
+  return 1
+}
+
+#
+# load compilers, allow a prefix
+#
+load_native_compilers()
+{
+  local PREFIX="$1"
+  local SUFFIX="$2"
+
+  if [ -n "$NESTED" ]
+  then
+    GOTO_GCC_NATIVE_COMPILER="/bin/true"
+    GOTO_GCC_NATIVE_LINKER="/bin/true"
+    GOTO_GCC_NATIVE_AR="/bin/true"
+  else
+    load_compilers "$PREFIX" "$SUFFIX"
+  fi
+}
+
+#
+# locate an executable
+#
+find_native()
+{
+  local cmd="$1"
+
+  if [ -n "$NESTED" ]
+  then
+    echo "/bin/true"
+  else
+    if which "$cmd" > /dev/null 2>&1
+    then
+      which "$cmd" 2>/dev/null
+    else
+      echo "/bin/false"
+    fi
+  fi
+}
+
+#
+# check whether all necessary tools are there
+#
+load_tools()
+{
+  PREFIX="$1"
+  SUFFIX="$2"
+
+  if [ "$GOTO_GCC_NATIVE_COMPILER" != "/bin/true" ]
+  then
+    load_compilers "$PREFIX" "$SUFFIX"
+  fi
+
+  GOTO_GCC_BINARY="$(which goto-gcc 2> /dev/null)"
+  GOTO_LD_BINARY="$(which goto-ld 2> /dev/null)"
+  GOTO_DIFF_BINARY="$(which goto-diff 2> /dev/null)"
+
+  # check whether the minimum set of tools is available
+  if [ -n "$WRAP_GOTOCC" ]
+  then
+    if [ ! -x "$GOTO_GCC_NATIVE_COMPILER" ] || [ ! -x "$GOTO_GCC_NATIVE_LINKER" ]\
+      || [ ! -x "$GOTO_GCC_BINARY" ] || [ ! -x "$GOTO_LD_BINARY" ] \
+      || [ ! -x "$GOTO_GCC_NATIVE_AR" ] || [ ! -x "$GOTO_DIFF_BINARY" ]
+    then
+      echo "error: did not find all necessary tools in the PATH environment"
+      echo "gcc:      $GOTO_GCC_NATIVE_COMPILER"
+      echo "ld:       $GOTO_GCC_NATIVE_LINKER"
+      echo "goto-gcc: $GOTO_GCC_BINARY"
+      echo "goto-ld:  $GOTO_LD_BINARY"
+      echo "goto-diff:$GOTO_DIFF_BINARY"
+      echo "abort setup"
+      return 1
+    fi
+  fi
+  return 0
+}
+
+# portable implementation of realpath
+function full_path
+{
+  local f="$1"
+  if readlink -f / >/dev/null 2>&1
+  then
+    readlink -f $f
+  else
+    if [[ "$f" =~ ^/ ]]
+    then
+      echo "$f"
+    else
+      echo "$(pwd -P)/""$f"
+    fi
+  fi
+}
+
+#
+# create the target directory
+#
+create_environment ()
+{
+  # check whether a target directory can be used
+  local KEEP_DIRECTORY=--keep-dir
+  if [ -n "$TARGET_DIRECTORY" ]
+  then
+      FULLDIRECTORY=$(full_path "$TARGET_DIRECTORY")
+      if [ -d "$FULLDIRECTORY" ]
+      then
+        if [ -e $FULLDIRECTORY/.checked-ok ]
+        then
+          rm $FULLDIRECTORY/.checked-ok
+        elif [ -e $FULLDIRECTORY/.checked-missing ]
+        then
+          echo "warning: target directory $TARGET_DIRECTORY did not exist"
+          rm $FULLDIRECTORY/.checked-missing
+        else
+          [ -z "$USE_EXISTING_DIR" ] && echo "warning: target directory $TARGET_DIRECTORY already exists"
+        fi
+      else
+        KEEP_DIRECTORY=
+        if ! mkdir "$FULLDIRECTORY" 2> /dev/null
+        then
+          echo "error: creating the target directory finished with a failure - abort"
+          return 1
+        fi
+        if [ -n "$USE_EXISTING_DIR" ]
+        then
+          echo "warning: target directory $TARGET_DIRECTORY did not exist"
+          touch $FULLDIRECTORY/.checked-missing
+        else
+          touch $FULLDIRECTORY/.checked-ok
+        fi
+      fi
+  fi
+
+  if [ -n "$NESTED" ]
+  then
+    mkdir -p build-tools/bin
+    GOTO_GCC_WRAPPER_INSTALL_DIR=$(full_path build-tools/bin)
+  elif [ -n "$TARGET_DIRECTORY" ]
+  then
+    GOTO_GCC_WRAPPER_INSTALL_DIR="$FULLDIRECTORY"
+  else
+    # create a (temporary) target directory where the wrapper goes to
+    GOTO_GCC_WRAPPER_INSTALL_DIR="$(mktemp -d)"
+  fi
+
+  if [ "$USE_EXISTING_DIR" = "trunc" ]
+  then
+    # currently, use a white list approach for clean up
+    rm -f "$FULLDIRECTORY"/{binaries.list,build.log,environmentInfo.txt,wrapper-log.txt,libraries.list}
+    rm -f "$FULLDIRECTORY/Fortify/fortify-preprocess.log"
+    rm -f "$FULLDIRECTORY/log/fortify-scan.log"
+  fi
+
+  # memorize old path, if it has not been set before
+  if [ -z "$PRE_GOTO_GCC_WRAPPER_PATH" ]
+  then
+    PRE_GOTO_GCC_WRAPPER_PATH="$PATH"
+  fi
+}
+
+#
+# install wrappers for nested builds
+#
+nested_wrappers()
+{
+  local last_tool=$1
+
+  for f in $GOTO_GCC_WRAPPER_INSTALL_DIR/$last_tool/*
+  do
+    bn=$(basename $f)
+    ln -s $last_tool/$bn $GOTO_GCC_WRAPPER_INSTALL_DIR/$bn
+  done
+  cp "$SOURCE_DIR/../backends/cflags/cflags-wrapper.sh" "$GOTO_GCC_WRAPPER_INSTALL_DIR/cflags"
+  perl -p -i -e "s:XX/tmp/cflags-wrapper-lockXX:$FULLDIRECTORY/wrapper-lock:" "$GOTO_GCC_WRAPPER_INSTALL_DIR/cflags"
+  echo "$(which "objcopy" 2> /dev/null) \"\$@\"" > "$GOTO_GCC_WRAPPER_INSTALL_DIR"/x86_64-unknown-linux-gnu-objcopy
+  chmod a+x "$GOTO_GCC_WRAPPER_INSTALL_DIR"/x86_64-unknown-linux-gnu-objcopy
+}
+
+
+#
+# main script
+#
+# only execute, if options can be parsed and all necessary tools can be found
+if parse_arguments "$@" && load_native_compilers
+then
+
+  # setup environment
+  if create_environment
+  then
+    cp "$SOURCE_DIR/ols-library.sh" "$GOTO_GCC_WRAPPER_INSTALL_DIR/"
+
+    # wrap cppcheck
+    if [ -n "$WRAP_CPPCHECK" ]
+    then
+      source "$SOURCE_DIR/../backends/cppcheck/cppcheck-hook-install.sh"
+      inject_cppcheck
+      load_compilers
+    fi
+
+    # wrap plain
+    if [ -n "$WRAP_PLAIN" ]
+    then
+      source "$SOURCE_DIR/../backends/plain/plain-hook-install.sh"
+      inject_plain
+      load_compilers
+    fi
+
+    # wrap Fortify
+    if [ -n "$WRAP_FORTIFY" ]
+    then
+      source "$SOURCE_DIR/../backends/fortify/fortify-hook-install.sh"
+      inject_fortify
+      # need to re-load the compiler locations, as Fortify wrappers have been installed
+      load_compilers
+      [ -z "$NESTED" ] || nested_wrappers Fortify
+    fi
+
+    # wrap AFL
+    if [ -n "$WRAP_AFL" ]
+    then
+        source "$SOURCE_DIR/../backends/AFL/AFL-hook-install.sh"
+        inject_afl
+        load_compilers
+        [ -z "$NESTED" ] || nested_wrappers AFL
+    fi
+
+    # wrap goto-(g)cc
+    if load_tools
+    then
+      # run the actual injection
+      source "$SOURCE_DIR/../backends/cbmc/gotocc-hook-install.sh"
+      [ -z "$WRAP_GOTOCC" ] || inject_gotocc
+    fi
+  fi
+fi

--- a/configuration/one-line-scan
+++ b/configuration/one-line-scan
@@ -1,0 +1,389 @@
+#!/bin/bash
+#
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Build project binaries with goto-gcc, or afl-gcc, or other backends.
+#
+# Usage: see usage() function below
+
+#
+# default script arguments
+#
+# default arguments
+NOANALYSIS=              # by default, we use analysis
+LINK=--link              # by default, enforce goto-ld for linking
+USE_AFL=                 # tell injection to also wrap for afl
+USE_GOTOCC=--use-gotocc  # tell injection to also wrap for goto-cc (CPROVER)
+USE_FORTIFY=             # tell injection to also wrap for Fortify
+USE_CPPCHECK=            # analyze with cppcheck
+FORTIFY_ANALYSIS_CONFIG= # extra options that should be passed to analysis of fortify
+USE_PLAIN=               # use a simple plain wrapper to log gcc calls
+EXPERT=                  # options that will be forwarded to the wrapper
+WORKINGDIR=OLS           # the default output directory
+USE_EXISTING=            # use output directory even if it exists already
+CONTINUE=                # only perform analysis, use existing directory
+KEEP_GOING=              # continue build with make, if single targets fail
+NUM_LOCKS=2              # use multiple compiler processes in parallel
+STOP_AFTER_FAIL=         # do not perform analysis if build did not return with 0
+EXTRA_CFLAGS=            # add these options to the injection setup call
+ANALYSIS_OPTIONS=        # additional options that can be specified to the analysis tools
+BINARY_ORIGIN=           # place where the analyzed binary comes from (to track binaries more easily)
+TOOLPREFIX=              # might wrap a variant of gcc additionally to gcc
+TOOLSUFFIX=              # might wrap a variant of gcc additionally to gcc
+GITUPSTREAM=             # display findings only for commits made after this ID
+GITBRANCH=               # display findings only for commits until this point
+
+
+# locate the script to be able to call related scripts
+SCRIPT=$(readlink -e "$0")
+SCRIPTDIR=$(dirname "$SCRIPT")
+
+# functions that are used
+source "$SCRIPTDIR"/utils/log.sh
+
+# rewrite first argument to a directory name that does not exist yet
+rewriteToNonexisting ()
+{
+	if [ -z $1 ]
+	then
+		return
+	fi
+
+	local STARTDIR="$1"
+	local TRY=0
+
+	local FINALDIR="$STARTDIR"
+	while [ -d "$FINALDIR" ]
+	do
+		echo "directory $FINALDIR exists already" 1>&2
+		TRY=$(($TRY+1))
+		FINALDIR="$STARTDIR$TRY"
+	done
+	echo "$FINALDIR"
+}
+
+# store environment when building with one-line-scan
+storeEnvironmentInfo()
+{
+  LOG="$1"/environmentInfo.txt
+  shift
+
+  echo "Build command: $@" > $LOG
+  echo "CBMC version: $(cbmc --version 2> /dev/null)" >> $LOG
+  echo "CBMC creation date: $( ls -lh $(which cbmc 2> /dev/null) | awk '{print $6,$7,$8}' )" >> $LOG
+  echo "Calling directory: $(pwd)" >> $LOG
+  echo "Content of the calling directory:" >> $LOG
+  ls -lh >> $LOG 2>&1
+  echo "Environment variables:" >> $LOG
+  env >> $LOG 2>&1
+}
+
+usage()
+{	
+  cat << EOF
+usage: [ENVIRONMENTSETUP] one-line-scan [OPTIONS] -- <build-command>
+
+  ENVIRONMENTSETUP:
+    Set environment variables before the one-line-scan command
+
+  OPTIONS:
+    --help       (-h)     show this help
+    --debug      (-d)     run in verbose mode and display commands before they are executed
+    --continue   (-c)     continue with the build of a given directory and (re)perform analysis
+    --no-analysis         only build, omit analysis
+    --expert ARG          forward ARG directly to compiler wrapper setup
+    --no-link             allow to fall back to native linker in case goto-ld fails
+    --afl                 additionally apply compilation for fuzzing with AFL
+    --fortify             run HP Fortify's sourcecodeanalyzer
+    --cppcheck            analyze with cppcheck
+    --no-gotocc           disable default goto-cc compilation
+    --plain               log compiler calls with plain wrapper
+    --prefix PRF          additionally to gcc also wrap "PRF"gcc (will not be combined with suffix)
+    --suffix SUF          additionally to gcc also wrap gcc"SUF" (will not be combined with prefix)
+    --output DIR (-o DIR) set the output directory to DIR
+    --forward A B         during execution, a call to command A is replaced with a call to B
+    --use-existing        use output directory even if it already exists
+    --trunc-existing      use output directory even if it already exists, but clear binaries/libraries of previous calls
+    --origin S            string that represents the origin of the analyzed project (git repository, web page, ...)
+    --keep-going          when the build process uses "make", use make -k instead
+    -j N                  allow the usage of N compiler processes in parallel (at least 2, might cause a mixed up log)
+    --stop-after-fail     do not perform analysis, if build process returned with non-zero value
+    --extra-cflags OPT    add this option to each compiler call (not linker), can be specified multiple times
+    --extra-cflag-set OPT add this option to each compiler call (not linker), OPT will be split by whitespace, each item will be added
+    --include-warnings    warn about redundant #include statements
+    --symex               perform analysis with symex instead of CBMC
+    --analysis-time time  add a maximal analysis time (in seconds)
+    --display-upstream ID display findings only for commits made after ID
+    --display-branch ID   display findings only for commits until this ID
+EOF
+}
+
+#
+# actual script
+#
+
+if [ -z "$*" ]
+then
+  usage
+  exit 1
+fi
+
+USER_SPECIFIED_DIR=
+# parse arguments
+while [ $# -gt 0 ]
+do
+    case $1 in
+    --help | -h)   usage; exit 0;;
+    --debug | -d)  set -x;;
+    --no-analysis) NOANALYSIS=t;;
+    --no-link)     LINK=;;
+    --afl)         USE_AFL="--afl";;
+    --cppcheck)    USE_CPPCHECK="--cppcheck" ;;
+    --fortify)     USE_FORTIFY="--fortify";;
+    --fortify-rules)  if [ -n "$2" ]
+                      then
+                        FORTIFY_ANALYSIS_CONFIG="$FORTIFY_ANALYSIS_CONFIG --rules $2"
+                        shift
+                      else
+                        echo "warning: specified --rules parameter without value"
+                      fi
+                      ;;
+    --no-gotocc)   USE_GOTOCC="--no-gotocc";;
+    --expert)      if [ -n "$2" ]
+                   then
+                     EXPERT=" $EXPERT "$2""
+                     shift
+                   else
+                     echo "warning: specified --expert value without parameter"
+                   fi
+                   ;;
+    --plain)       USE_PLAIN="--plain";;
+    --prefix)      if [ -n "$2" ]
+                   then
+                     TOOLPREFIX+=" --prefix $2"
+                     shift
+                   fi
+                   ;;
+    --suffix)      if [ -n "$2" ]
+                   then
+                     TOOLSUFFIX+=" --suffix $2"
+                     shift
+                   fi
+                   ;;
+    --output | -o) WORKINGDIR=$2
+                   USER_SPECIFIED_DIR=t
+                   shift
+                   ;;
+    --use-existing)   USE_EXISTING=--re-use;;
+    --trunc-existing) USE_EXISTING=--trunc;;
+    --origin)      BINARY_ORIGIN=$2; shift;;
+    --continue | -c) CONTINUE=t;;
+    --keep-going)  KEEP_GOING=t;;
+    -j)            if [[ "$2" =~ ^[0-9]+$ ]] && [ $2 -ge 2 ]
+                   then
+                     NUM_LOCKS=$2
+                     shift
+                   else
+                     echo "warning: specified -j without a number, will not change value"
+                   fi
+                   ;;
+    --stop-after-fail) STOP_AFTER_FAIL=t;;
+    --extra-cflags) if [ -n "$2" ]
+                    then
+                      EXTRA_CFLAGS="$EXTRA_CFLAGS --extra $2"
+                      shift
+                    fi
+                    ;;
+    --extra-cflag-set) if [ -n "$2" ]
+                       then
+                         for flag in $2
+                         do
+                           EXTRA_CFLAGS+=" --extra $flag"
+                         done
+                         shift
+                       fi
+                       ;;
+    --symex)         ANALYSIS_OPTIONS="$ANALYSIS_OPTIONS --symex";;
+    --analysis-time) ANALYSIS_OPTIONS="$ANALYSIS_OPTIONS --timeout $2"; shift;;
+    --include-warnings) EXTRA_CFLAGS="--include-warnings $EXTRA_CFLAGS";;
+    --forward)      if [ -n "$3" ] && which "$3" &> /dev/null
+                    then
+                      EXTRA_CFLAGS="--forward $2 $3 $EXTRA_CFLAGS"
+                      shift 2
+                    fi ;;
+    --display-upstream) GITUPSTREAM="$2"; shift;;
+    --display-branch)   GITBRANCH="$2"; shift;;
+    --)            shift; break ;;
+    *)             echo "warning: unknown parameter $1, have you forgotten the '--'? continue with build." 1>&2; break ;;
+    esac
+    shift
+done
+
+# do not continue if no parameter is present
+if [ -z "$*" ]; then
+	log "stop due to missing build command"
+	exit 0
+fi
+
+# should we call sub scripts with tracing?
+SCRIPT_CALLER=
+[[ "$-" != *"x"* ]] || SCRIPT_CALLER="bash -x "
+
+# check whether user specified directory is already there, if we want to build
+if [ -n "$USER_SPECIFIED_DIR" ] && \
+   [ -d "$WORKINGDIR" ] && \
+   [ -z $CONTINUE ] && \
+   [ -z $USE_EXISTING ]
+then
+  echo "error: output directory $WORKINGDIR exists already"
+  exit 1
+fi
+
+# the command to be executed
+log "build command to be executed: $@"
+
+# check whether we can actually execute the command
+if ! command -v $1 &> /dev/null
+then
+  log "error: cannot execute '$@', abort"
+  exit 1
+fi
+
+# relative path to gcc wrapper tools
+INJECT_TOOLS=$SCRIPTDIR/inject-gcc-wrapper
+ANALYSIS_TOOLS=$SCRIPTDIR/cbmc-analysis
+
+# Try to figure out the origin of the project automatically
+if [ -z "$BINARY_ORIGIN" ]
+then
+  GIT_REPOSITORY=$(git remote -v 2> /dev/null | grep "^origin" | awk '/(fetch)/ {print $2}')
+  GIT_COMMIT=$(git rev-parse --short HEAD 2> /dev/null)
+  BINARY_ORIGIN="$GIT_REPOSITORY#$GIT_COMMIT"
+  [ -n "$GIT_COMMIT" ] || BINARY_ORIGIN="$(hostname):$(pwd)"
+fi
+
+# setup a working directory
+# variable will be rewritten to a non-existing directory name, if we did not specify --continue
+if [ -z $CONTINUE ] && [ -z "$USER_SPECIFIED_DIR" ] && [ -z $USE_EXISTING ]
+then
+  WORKINGDIR=$(rewriteToNonexisting $WORKINGDIR)
+fi
+
+BUILDRESULT=0
+if [ -z $CONTINUE ]
+then
+  log "working directory: $WORKINGDIR"
+
+  # construct call for injection
+  EXTRA_INJECT_OPTIONS=
+  if [ -n "$KEEP_GOING" ]
+  then
+    log "add --keep-going to the setup call"
+    EXTRA_INJECT_OPTIONS="$EXTRA_INJECT_OPTIONS --keep-going"
+  fi
+
+  WRAPPER_SETUP_OPTIONS="--target "$WORKINGDIR" --origin "$BINARY_ORIGIN" \
+    "$LINK" "$USE_EXISTING" "$USE_AFL" "$USE_FORTIFY" \
+    "$TOOLPREFIX" "$TOOLSUFFIX" -j $NUM_LOCKS "$EXTRA_INJECT_OPTIONS" "$EXTRA_CFLAGS" \
+    "$EXPERT" "$USE_GOTOCC"  $USE_CPPCHECK $USE_PLAIN"
+  log $(echo "setting up wrapper with: $WRAPPER_SETUP_OPTIONS" | sed 's/  */ /g')
+
+  # check whether the environment is actually usable for the wrapper injection
+  TMP_ERROR=$(mktemp)
+  if ! $SCRIPT_CALLER "$INJECT_TOOLS"/check-setup.sh $WRAPPER_SETUP_OPTIONS > $TMP_ERROR 2>&1
+  then
+    echo "error: check for injecting compiler wrapper failed - abort" 1>&2
+    cat $TMP_ERROR 2> /dev/null
+    rm -f $TMP_ERROR
+    exit 1
+  else
+    log "wrapper injection check succeeds"
+  fi
+  rm -f $TMP_ERROR
+
+  # setup the goto-gcc environment, use goto-ld as linking tool
+  source $INJECT_TOOLS/setup.sh $WRAPPER_SETUP_OPTIONS
+
+  # store information about the build environment
+  storeEnvironmentInfo $WORKINGDIR "$@"
+
+  # execute the actual build, store stdout and stderr in build.log
+  log "execute build command"
+  "$@" \
+    > >(tee -a "$WORKINGDIR"/build.log) 2>&1 || BUILDRESULT=$?
+
+  # restore location to gcc, keep directory
+  source $INJECT_TOOLS/remove-wrapper.sh --keep-dir
+
+  # display the result of the build
+  log "status of the build: $BUILDRESULT"
+else
+  log "perform analysis in working directory: $WORKINGDIR"
+  if [ ! -d $WORKINGDIR ]
+  then
+    log "working directory $WORKINGDIR does not exists - abort"
+    exit 1
+  fi
+fi
+
+# stop with build result, if requested
+if [ ! -z $STOP_AFTER_FAIL ] && [ $BUILDRESULT -ne 0 ]
+then
+  log "stop after build failed with exit status $BUILDRESULT"
+  exit $BUILDRESULT 
+fi
+
+mkdir -p $WORKINGDIR/log
+# perform analysis only if not forbidden before
+ANALYSISRESULT=0
+
+# evaluate cppcheck
+if [ -z $NOANALYSIS ] && [ -n "$USE_CPPCHECK" ]
+then
+  log "evaluate cppcheck findings ..."
+  source "$SCRIPTDIR/backends/cppcheck/cppcheck-evaluate.sh"
+  evaluate_cppcheck || ANALYSISRESULT=$?
+fi
+
+# evaluate plain
+if [ -z $NOANALYSIS ] && [ -n "$USE_PLAIN" ]
+then
+  log "evaluate plain wrapper ..."
+  source "$SCRIPTDIR/backends/plain/plain-evaluate.sh"
+  evaluate_plain || ANALYSISRESULT=$?
+fi
+
+# evaluate fortify
+if [ -z $NOANALYSIS ] && [ -n "$USE_FORTIFY" ]
+then
+  log "evaluate fortify wrapper ..."
+  source "$SCRIPTDIR/backends/fortify/fortify-evaluate.sh"
+  evaluate_fortify || ANALYSISRESULT=$?
+fi
+
+# check CBMC data
+if [ -z "$NOANALYSIS" ] && [ "$USE_GOTOCC" == "--use-gotocc" ]
+then
+  log "evaluate cbmc wrapper ..."
+  source "$SCRIPTDIR/backends/cbmc/cbmc-evaluate.sh"
+  evaluate_cbmc || ANALYSISRESULT=$?
+fi
+
+# in case of an error, select the exit code with the error, prioritize analysis over build
+if [ "$ANALYSISRESULT" -eq 0 ]
+then
+  exit $BUILDRESULT
+else
+  exit $ANALYSISRESULT
+fi

--- a/configuration/utils/display-series-data.sh
+++ b/configuration/utils/display-series-data.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# This scripts matches each line of a datafile with file and line info to the changes
+# that have been introduced in a certain commit range, between upstream and branch.
+# If no git IDs are specified, the full data file is printed (after sorting).
+#
+# USAGE: ./display-series-data.sh DATAFILE [UPSTREAMGITID [BRANCHGITID]]
+#	 DATAFILE file with the data to display, of the format <file>:<line>:message
+#        UPSTREAMGITID show coverity defects introduced since this ID,
+#              if not specified show all found defects
+#        BRANCHGITID show introduced coverity defects introduced since this ID,
+#              if not specified, show all defects until the current commit
+#
+
+log() {
+	echo "$@" 1>&2
+}
+
+error() {
+	log "$@"
+	exit 1
+}
+
+DATAFILE=
+UPSTREAMGITID=
+BRANCHGITID=HEAD
+
+if [ -n "$*" ]; then
+	DATAFILE="$1"
+	shift
+fi
+
+if [ -n "$2" ]; then
+    	# try to get a nice description of the upstream commit
+	BRANCHGITID="$2"
+	GIT_STATUS=0
+	headid=$(git rev-parse $BRANCHGITID || GIT_STATUS=$?)
+	if [ $GIT_STATUS -ne 0 ]; then
+		error "error: cannot find $BRANCHGITID as reference in git history, abort."
+	fi
+	# try to find branch (some) pointer
+	branches=$(git branch --contains $BRANCHGITID | grep -v " detached at ")
+	for branch in $branches; do
+		branchid=$(git rev-parse $branch)
+		if [ $branchid = $headid ]; then
+			BRANCHGITID="$branch"
+			break
+		fi
+	done
+fi
+
+if [ -n "$1" ]; then
+	UPSTREAMGITID="$1"
+	GIT_STATUS=0
+	git rev-list --count "$BRANCHGITID" ^$UPSTREAMGITID &> /dev/null || GIT_STATUS=$?
+	if [ $GIT_STATUS -ne 0 ]; then
+		error "error: cannot find $UPSTREAMGITID as reference in git history, abort."
+	fi
+	log "map defects to commits $UPSTREAMGITID to $BRANCHGITID"
+fi
+
+# have one directory where are temporary files go to
+TMPDIR=$(mktemp -d --tmpdir=$TMPDIR display-series-data-XXXXXX)
+trap 'rm -rf $TMPDIR' EXIT
+
+SUMMARIZE_STATUS=0
+# show partial results based on git blame, or full results
+if [ -n "$UPSTREAMGITID" ]; then
+	# get number of last commits to look at
+	ANALYZE_LAST_COMMITS=$(git rev-list --count $BRANCHGITID ^$UPSTREAMGITID)
+
+	CHANGED_FILES="$TMPDIR"/changed-files.txt
+	CHANGED_LOCATIONS="$TMPDIR"/changed-locations.txt
+	JOIN1="$TMPDIR"/join1.txt
+	JOIN2="$TMPDIR"/join2.txt
+
+	# check whether the referenced commits changed anything
+	for commit in $(seq 0 $(($ANALYZE_LAST_COMMITS-1))); do
+		git diff-tree --no-commit-id --name-only -r $BRANCHGITID~$commit > $CHANGED_FILES
+
+		PAT=$(git rev-parse HEAD~$commit)
+		cat $CHANGED_FILES | while IFS="" read -r filename; do
+			# get all lines for current commit with line number, only print the filename
+			# and line number
+			git blame -l -s $filename 2> /dev/null | grep -n "^$PAT" 2> /dev/null | \
+				awk -F : -v fn="$filename" '{if($1+0 > 0) print fn ":" $1 ","}' \
+				2> /dev/null >> $CHANGED_LOCATIONS
+		done
+	done
+
+	# sort all found locations, and match them against the locations of the findings
+	cat $CHANGED_LOCATIONS | sort -k 1b,1 | uniq > $JOIN1
+	awk -F: '{print $1 ":" $2}' "$DATAFILE" | sort -k 1b,1 | uniq > $JOIN2
+	join $JOIN1 $JOIN2 > $CHANGED_LOCATIONS
+
+	# display actually found problems
+	NUM_HIT_LINES=$(cat $CHANGED_LOCATIONS | wc -l)
+	log "found items introduced during last $ANALYZE_LAST_COMMITS ($UPSTREAMGITID to $BRANCHGITID) commits: $NUM_HIT_LINES"
+
+	# set status back to 0, if no defects have been introduced in this series
+	[ $NUM_HIT_LINES -gt 0 ] || SUMMARIZE_STATUS=0
+
+	rm $JOIN2
+	cat $CHANGED_LOCATIONS | while IFS="" read -r location; do
+		grep "^${location}:" "$DATAFILE" >> $JOIN2
+	done
+	[ -f $JOIN2 ] && sort $JOIN2 | uniq
+else
+	sort "$DATAFILE"
+fi
+
+# clean up and exit
+exit $SUMMARIZE_STATUS

--- a/configuration/utils/insert-code.py
+++ b/configuration/utils/insert-code.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+
+import fileinput
+import sys
+
+print len(sys.argv)
+print sys.argv
+
+if ( len(sys.argv) < 2 ):
+    print "usage: insert-code.py [--comment] code-file"
+    print "   --comment  will add each statement as a commend (with prefix '//')"
+    print "   code-file  text file of the form filename:linenumber:statement for each line"
+    sys.exit(0)
+
+comment=0
+if (sys.argv[1] == "--comment" ):
+    comment=1
+
+if (len(sys.argv) < 3 ):
+    print "error: no code file specified, abort"
+    sys.exit(1)
+
+statements = []
+with open(sys.argv[1+comment], 'r') as outfile:
+    statements = outfile.readlines()
+
+files = {}
+
+for line in statements:
+    tokens = line.split(':')
+    if( len(tokens) < 3 ):
+      continue
+
+    filename = tokens[0]
+    lineno = int(tokens[1])
+    statement_begin = line.replace(':',' ',1).find(':')+1
+    statement = line[statement_begin:]
+    # add the element in the set, if there has been a list before
+    if filename not in files:
+        files[filename] = []
+    # append the current line to the set of files
+    files[filename].append( (lineno, statement) )
+
+for filename in files:
+    print "workon " + filename
+    # sort the statements to be inserted, so that we can process the file
+    # linearly
+    statementlist = sorted(files[filename] )
+
+    # keep track of statements and where to put them
+    nextStatement = 0
+    nextStatementLineno = statementlist[ nextStatement ][0]
+    lastPrinted = 0
+    # open the file and add the lines
+    for line in fileinput.input(filename, inplace=1):
+      # currentLine = currentLine + 1
+      # if we still have statements to insert
+      if ( nextStatement != -1 ):
+        # check whether we should do so on the current line
+        while ( nextStatementLineno == fileinput.lineno() ):
+          spacePrefix = len(line) - len(line.lstrip()) - 1
+          if( lastPrinted != nextStatementLineno ):
+            print ""
+          if ( comment == 1 ):
+            print "//",
+          print line[0:spacePrefix],
+          print statementlist[ nextStatement ][1],
+          # check if there is a next statement
+          if ( nextStatement + 1 >= len(statementlist)):
+            nextStatement = -1
+            break
+          else:
+            # select next statement and memorize its line number
+            nextStatement = nextStatement + 1
+            lastPrinted = nextStatementLineno
+            nextStatementLineno = statementlist[ nextStatement ][0]
+      # finally, print the line of code
+      print line,

--- a/configuration/utils/limit-resources.sh
+++ b/configuration/utils/limit-resources.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Calculate the amount of resources that are allowed to be use be a script
+# Use ulimit to enforce these limits
+#
+# This script should be sourced by other scripts
+
+
+# check the available memory, and return 40% is large enough, otherwise return
+# almost the full amount (leave 256M is possible)
+# returns the number in K
+usable_memory()
+{
+ grep -e "^MemAvailable:" -e "^MemTotal:" /proc/meminfo \
+   | sort -V | head -n 1 \
+   | awk 'BEGIN {
+            freemem=0; M=1024; G=1024 * 1024
+            OFMT = "%.0f"
+          }
+          {
+            if ( $2 + 0 >= 0 ) freemem=$2;
+          }
+          END {
+                if( freemem  > 10 * G ) {
+                  freemem = (freemem * 2) / 5;
+                } else {
+                  if (freemem > (512 * M)) freemem = freemem - (256 * M)
+                }
+                print freemem;
+              }
+         '
+}
+
+# return the available memory in M
+usable_memory_in_M()
+{
+  usableMemory=$(usable_memory)
+  echo "$(($usableMemory/1024))"
+}
+
+# make this a function, so that variables are local
+limit_memory()
+{
+  # get available memory, if more then 3GB, use 75%, otherwise, use all
+  # and leave 256M if possible, if we can have 256 as well
+  local usableMemory=$(usable_memory)
+  # if we obtained a value, assign the limitation to avoid freezing the machine
+  if [ -n "$usableMemory" ] && [ $usableMemory -ne 0 ]
+  then
+    ulimit -S -v $usableMemory
+  fi
+}

--- a/configuration/utils/log.sh
+++ b/configuration/utils/log.sh
@@ -1,0 +1,25 @@
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  or in the "license" file accompanying this file. This file is distributed 
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+#  express or implied. See the License for the specific language governing 
+#  permissions and limitations under the License.
+#
+# Provide the method for logging
+
+log()
+{
+  echo "$*" | while IFS="" read -r line; do
+  if [ -z "$TERM" ]; then
+    echo "$(date -u "+%F %T%z" | sed 's/..$/:&/')$(tput setaf 6) $line$(tput sgr0)"
+  else
+    echo "$(date -u "+%F %T%z" | sed 's/..$/:&/') $line"
+  fi
+  done
+}

--- a/one-line-scan
+++ b/one-line-scan
@@ -1,0 +1,1 @@
+configuration/one-line-scan

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -1,0 +1,7 @@
+DIRS =  $(filter-out Makefile, $(wildcard *))
+
+test:
+	$(foreach var,$(DIRS), $(MAKE) -C $(var) test;)
+
+clean:
+	$(foreach var,$(DIRS), $(MAKE) -C $(var) clean;)

--- a/regression/analysis/Makefile
+++ b/regression/analysis/Makefile
@@ -1,0 +1,7 @@
+DIRS =  $(filter-out Makefile, $(wildcard *))
+
+test:
+	$(foreach var,$(DIRS), $(MAKE) -C $(var) test || exit 1;)
+
+clean:
+	$(foreach var,$(DIRS), $(MAKE) -C $(var) clean;)

--- a/regression/analysis/afl-mini/Makefile
+++ b/regression/analysis/afl-mini/Makefile
@@ -1,0 +1,5 @@
+test:
+	./run.sh
+
+clean:
+	rm -rf fuzzing 

--- a/regression/analysis/afl-mini/read-stdin.c
+++ b/regression/analysis/afl-mini/read-stdin.c
@@ -1,0 +1,36 @@
+// In this file a buffer overflow is present, that can be triggered when calling
+// the binary and do not begin the input to the program with a number. When the
+// number is too high, or the input is too long, invalid memory accesses can
+// happen as well.
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+int main(int argc, char **argv )
+{
+  int i = 0, index = -1, number = 0;
+  char buffer [16];
+  int elements = scanf("%s", buffer);
+
+  if ( buffer[0] == 'A' ) index = -256;
+
+  while( buffer[i] >= '0' && buffer[i] <= '9' )
+  {
+    number = number * 10 + (buffer[i] - '0');
+    index = i;
+    ++i;
+  }
+
+  printf("number: %d\n", number);
+  printf("last digit: %c at %d \n", buffer[index], index);
+
+  assert( (index < -100 || index >= 0) && "wonder whether we can ever get here after the buffer access above" );
+
+  if (elements % 8 == 0 ) {
+    buffer[elements] = 'A';
+    printf("new buffer: %s\n", buffer);
+  }
+
+  return 0;
+}

--- a/regression/analysis/afl-mini/run.sh
+++ b/regression/analysis/afl-mini/run.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# check whether we can binaries that can be fuzzed with AFL, and which actually
+# trigger crashes that are found by the fuzzer
+
+# if one of the commands fail without the test case being prepared, it should be
+# a failure
+set -e
+
+if ! which afl-fuzz
+then
+  echo "cannot find afl-fuzz - abort with success as this is not the fault of the test"
+  exit 0
+fi
+
+# start from scratch, as some commands do not work when the output directory
+# already exists
+D=fuzzing
+rm -rf $D
+mkdir -p $D
+
+# tell script about AFL
+AFL_LOCATION=$(which afl-gcc)
+export AFL_PATH=$(dirname "$AFL_LOCATION")
+
+# make sure we are actually resulting in the same binary/assembly
+afl-gcc read-stdin.c -g -o $D/number-afl.o -c -ffunction-sections
+objdump -lSd fuzzing/number-afl.o | wc
+AFL_OBJECT_SIZE=$(objdump -lSd fuzzing/number-afl.o | wc | awk '{print $1,$2}')
+
+# compile the same object file with one-line-scan
+../../../configuration/one-line-scan --afl --no-gotocc -o $D/AFLO --no-analysis -- gcc read-stdin.c -g -o $D/number-afl.o -c -ffunction-sections
+objdump -lSd fuzzing/number-afl.o | wc
+SP_OBJECT_SIZE=$(objdump -lSd fuzzing/number-afl.o | wc | awk '{print $1,$2}')
+
+if [ $AFL_OBJECT_SIZE -ne $SP_OBJECT_SIZE ]
+then
+  echo "size of binaries with and without afl do not match - abort"
+  exit 1
+fi
+
+# compile with gcc, to check that we need instrumentation to use afl
+gcc read-stdin.c -g -o $D/number-gcc
+
+# compile with one-line-scan --afl
+../../../configuration/one-line-scan --afl --no-gotocc -o $D/AFL --no-analysis -- gcc read-stdin.c -o $D/number-afl
+
+if [ ! -x $D/number-afl ]
+then
+  echo "error: could not find compiled target binary - abort!"
+  exit 1
+fi
+
+# create test cases
+mkdir -p $D/in
+echo "123" > $D/in/123
+echo "ABC" > $D/in/abc
+echo "12A34" > $D/in/12A34
+
+# run afl on usual gcc binary should result in an error
+AFL_STATUS=0
+AFL_SKIP_CPUFREQ=1 timeout 10 afl-fuzz -i $D/in -o $D/AFL-OUT-gcc $D/number-gcc > /dev/null 2> /dev/null || AFL_STATUS=$?
+
+if [ $AFL_STATUS -eq 0 ]
+then
+  echo "error: binary created with gcc can fuzzed with AFL - abort"
+  exit 1
+fi
+
+# afl should easily find at least 2 problems in out example within the first 10
+# seconds of its run time (there are at least five that can be found)
+AFL_SKIP_CPUFREQ=1 timeout 10 afl-fuzz -i $D/in -o $D/AFL-OUT $D/number-afl || AFL_STATUS=$?
+
+if [ $AFL_STATUS -ne 124 ]
+then
+  echo "error: the fuzzer terminated before it's 10 second timeout - abort"
+  exit 1
+fi
+
+# there should be at least 2 problems
+CRASHES=$(awk '/^unique_crashes/ {print $3}' $D/AFL-OUT/fuzzer_stats)
+if [ $CRASHES -lt 2 ]
+then
+  echo "error: less than 2 crashes have been reported in 10 seconds ($CRASHES) - abort"
+  exit 1
+fi
+# there are no more test we do here
+exit 0

--- a/regression/analysis/cppcheck/Makefile
+++ b/regression/analysis/cppcheck/Makefile
@@ -1,0 +1,6 @@
+test:
+	./run.sh
+
+clean:
+	rm -rf src/T
+	$(MAKE) clean -C src

--- a/regression/analysis/cppcheck/run.sh
+++ b/regression/analysis/cppcheck/run.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# check whether the analysis reveals bugs that can be spotted by cppcheck
+
+# fail early
+set -e -x
+
+make clean -C src
+rm -rf src/T
+
+
+pushd src
+STATUS=0
+../../../../configuration/one-line-scan --cppcheck -o T --no-gotocc -- make &> output.log || STATUS=$?
+
+if [ "$STATUS" -eq 0 ]
+then
+	echo "error: error in code not signaled via exit code, abort"
+	exit 1
+fi
+
+# check whether code problems are found
+if ! grep "1 (style:unassignedVariable)" output.log
+then
+	echo "error: did not spot unassigned variable error, abort"
+	exit 1
+fi
+
+if ! grep "1 (error:uninitvar)" output.log
+then
+	echo "error: did not spot unassigned variable error, abort"
+	exit 1
+fi
+
+make clean
+popd
+
+exit 0

--- a/regression/analysis/cppcheck/src/Makefile
+++ b/regression/analysis/cppcheck/src/Makefile
@@ -1,0 +1,9 @@
+test: src.c subsrc/sub.o
+	gcc -o src.o -c src.c
+	gcc -o test src.o subsrc/sub.o
+
+subsrc/sub.o:
+	gcc -o subsrc/sub.o -c subsrc/sub.c
+
+clean:
+	rm -f subsrc/sub.o src.o test

--- a/regression/analysis/cppcheck/src/src.c
+++ b/regression/analysis/cppcheck/src/src.c
@@ -1,0 +1,6 @@
+int f();
+
+int main()
+{
+	return f();
+}

--- a/regression/analysis/cppcheck/src/subsrc/sub.c
+++ b/regression/analysis/cppcheck/src/subsrc/sub.c
@@ -1,0 +1,5 @@
+int f()
+{
+	int a;
+	return a;
+}

--- a/regression/analysis/cprover-analysis/Makefile
+++ b/regression/analysis/cprover-analysis/Makefile
@@ -1,0 +1,5 @@
+test:
+	./run.sh
+
+clean:
+	rm -rf SP buggy

--- a/regression/analysis/cprover-analysis/main.c
+++ b/regression/analysis/cprover-analysis/main.c
@@ -1,0 +1,46 @@
+// In this file a buffer overflow is present
+
+#include <stdio.h>
+#include <string.h>
+
+char *to_lower(char *orig)
+{
+	char lower[4];
+	int i = 0;
+	// original variant has a faulty implementation:
+	//strcpy(orig, lower);
+	// to produce something readable, lets actually copy the content to the string!
+	strcpy(lower, orig);
+	for ( ; i <= strlen(lower); ++i) {
+		// this reads/writes out of bounds
+		if (lower[i] >= 'A' && lower[i] <= 'Z') {
+			// this overflows, as + is served first and 'Z' + 'a' is beyond 128
+			lower[i] = lower[i] + 'a';
+			lower[i] = lower[i] - 'A';
+		}
+	}
+	// returning the pointer to a stack variable is not handled by CBMC yet
+	// however, gcc already complains with a warning, so we do not use this return here
+	// return &lower[0];
+	return orig;
+}
+
+
+int main(int argc, char **argv )
+{
+	char uninitialized_buffer [16];
+
+	if (argc < 2 ) return 0;
+
+	char *text = argv[1];
+	if (argc > 1 && argc % 2) {
+		printf("use uninit buffer\n");
+		text = uninitialized_buffer;
+	}
+
+	char *lower = to_lower( text );
+	printf( "sequence %d: %s\n", 0, text );
+	printf( "sequence %d: %s\n", 1, lower );
+
+	return 0;
+}

--- a/regression/analysis/cprover-analysis/run.sh
+++ b/regression/analysis/cprover-analysis/run.sh
@@ -1,0 +1,21 @@
+# check whether the analysis reveals bugs that can be spotted by humans
+
+rm -rf SP
+
+# test setup
+export CBMC_UNWIND=17
+export CBMC_DEPTH=10000
+
+# perform the analysis
+../../../configuration/one-line-scan -o SP -- gcc main.c -o buggy
+
+# show log of binary analysis
+FAILS=$(grep ": FAILURE" SP/log/violation/buggy-d$CBMC_DEPTH-uw$CBMC_UNWIND.cbmc.log | wc -l)
+
+# check the number and exit
+if [ -z "$FAILS" ] || [ "$FAILS" -lt 2 ]; then
+	echo "error: did not see all expected fails (2 overflow, 1 out of bounds)"
+	exit 1
+fi
+
+exit 0

--- a/regression/analysis/typical-bugs/Makefile
+++ b/regression/analysis/typical-bugs/Makefile
@@ -1,0 +1,5 @@
+test:
+	./run.sh
+
+clean:
+	rm -rf SP typical-bugs

--- a/regression/analysis/typical-bugs/run.sh
+++ b/regression/analysis/typical-bugs/run.sh
@@ -1,0 +1,13 @@
+# check whether the analysis reveals bugs that can be spotted by humans
+
+rm -rf SP
+
+export CBMC_UNWIND=4
+export CBMC_DEPTH=1000
+
+../../../configuration/one-line-scan -o SP -- gcc test.c -o typical-bugs
+
+# show log of binary analysis
+cat SP/log/violation/typical-bugs-d1000-uw4.cbmc.log
+
+exit 0

--- a/regression/analysis/typical-bugs/test.c
+++ b/regression/analysis/typical-bugs/test.c
@@ -1,0 +1,36 @@
+// In this file a buffer overflow is present, that can be triggered when adding
+// a string to the command line that contains more than 128 characters
+// Furthermore, a pointer to a stack variable is returned in a function.
+
+#include <stdio.h>
+#include <string.h>
+
+char *to_lower(char *orig)
+{
+	char lower[128];
+	int i = 0;
+	// original variant has a faulty implementation:
+	//strcpy(orig, lower);
+	// to produce something readable, lets actually copy the content to the string!
+	strcpy(lower, orig);
+	for ( ; i <= strlen(lower); ++i) {
+		if (lower[i] >= 'A' && lower[i] <= 'Z') {
+			lower[i] = lower[i] - 'A' + 'a';
+		}
+	}
+	return &lower[0];
+}
+
+
+int main(int argc, char **argv )
+{
+	int i = 0;
+	// make sure the loop is not called too often
+	int max = argc > 3 ? 3 : argc;
+	for ( ; i + 1 < argc; ++ i )
+	{
+		char *lower = to_lower( argv[i+1] );
+		printf( "sequence %d: %s\n", i, lower );
+	}
+	return 0;
+}

--- a/regression/compilation/Makefile
+++ b/regression/compilation/Makefile
@@ -1,0 +1,7 @@
+DIRS =  $(filter-out Makefile, $(wildcard *))
+
+test:
+	$(foreach var,$(DIRS), $(MAKE) -C $(var) test || exit 1;)
+
+clean:
+	$(foreach var,$(DIRS), $(MAKE) -C $(var) clean;)

--- a/regression/compilation/extra-cflags/Makefile
+++ b/regression/compilation/extra-cflags/Makefile
@@ -1,0 +1,5 @@
+test:
+	./run.sh
+
+clean:
+	rm -rf SP one-line-scan a.out

--- a/regression/compilation/extra-cflags/fail.c
+++ b/regression/compilation/extra-cflags/fail.c
@@ -1,0 +1,4 @@
+// When being compiled with -Wextra -Werror, the comparison in the return
+// statemant should trigger a compilation error
+
+int main() { unsigned u = 0; int i = 3; return u < i; }

--- a/regression/compilation/extra-cflags/run.sh
+++ b/regression/compilation/extra-cflags/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# test building with injected extra options
+
+
+# the usual compilation should not fail
+rm -rf SP
+../../../configuration/one-line-scan -o SP --stop-after-fail --no-analysis -- gcc -Wextra fail.c || exit 1
+
+# when using an additional -Werror, the compilation should fail
+rm -rf SP
+../../../configuration/one-line-scan -o SP --extra-cflags -Werror --no-analysis -- gcc -Wextra fail.c || exit 0
+
+# if we can reach this, the above command did not fail
+exit 1

--- a/regression/compilation/faulty-input/Makefile
+++ b/regression/compilation/faulty-input/Makefile
@@ -1,0 +1,5 @@
+test:
+	./run.sh
+
+clean:
+	rm -rf SP

--- a/regression/compilation/faulty-input/fail.c
+++ b/regression/compilation/faulty-input/fail.c
@@ -1,0 +1,1 @@
+int main() { int x[3]; int y[5] = x[3]; return y; }

--- a/regression/compilation/faulty-input/run.sh
+++ b/regression/compilation/faulty-input/run.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# execute failed build, check whether faulty output is present
+
+# make sure we run on a clean environment (otherwise we fail with "SP" exists)
+rm -rf SP
+../../../configuration/one-line-scan -o SP -- gcc fail.c
+
+# did we produce faulty input files?
+ls SP/faultyInput/*
+if [ $? -eq 0 ]
+then
+  echo "success"
+  cat SP/faultyInput/*
+  exit 0
+else
+  echo "fail"
+  exit 1
+fi

--- a/regression/compilation/git/Makefile
+++ b/regression/compilation/git/Makefile
@@ -1,0 +1,5 @@
+test:
+	./run.sh
+
+clean:
+	rm -rf SP

--- a/regression/compilation/git/run.sh
+++ b/regression/compilation/git/run.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# setup a dummy git repository
+  git init .
+  trap 'rm -rf .git' EXIT
+  git add test.c 
+  git commit -am "first test file"
+  git status
+  cp test.c a.c
+  git add a.c 
+  git commit -am "2nd file"
+  git log --decorate --pretty=oneline
+  echo ""
+
+# analyze
+  rm -rf SP
+  ../../../configuration/one-line-scan --debug --fortify --no-gotocc --display-upstream HEAD~1 -o SP -- gcc test.c 
+  echo $?
+  cat SP/log/fortify-summary-filtered.txt 
+  echo ""
+
+# analyze
+  rm -rf SP
+  ../../../configuration/one-line-scan --debug --fortify --no-gotocc --display-upstream HEAD~1 -o SP -- gcc a.c 
+  echo $?
+  echo "filtered:"
+  cat SP/log/fortify-summary-filtered.txt 
+  echo "full"
+  cat SP/log/fortify-summary.txt
+  echo ""
+
+# test for result
+  echo "test whether the defect is displayed"
+  if grep -f SP/log/fortify-summary.txt SP/log/fortify-summary-filtered.txt
+  then
+    echo "success"
+    rm -rf SP
+    exit 0
+  else
+    echo "git match test failed"
+    exit 1
+  fi

--- a/regression/compilation/git/test.c
+++ b/regression/compilation/git/test.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int a[3];
+  a[3]=0;
+  return a[0];
+}


### PR DESCRIPTION
This commit adds the first version of one-line-scan. The basic
functionality is implemented, as well as basic documentation is
given.

The list of working back-ends is AFL, CBMC, cppcheck, fortify
and plain.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
