### PR TITLE
plain: add compilation database

### DIFF
--- a/configuration/backends/plain/plain-evaluate.sh
+++ b/configuration/backends/plain/plain-evaluate.sh
@@ -19,9 +19,24 @@ function evaluate_plain
   local -r RESULTS_DIR="$WORKINGDIR/plain"
   local -r CALLLOG="$RESULTS_DIR/calls.json"
   local -r REPLAYLOG="$RESULTS_DIR/replay.log"
+  local -r CMDB="$RESULTS_DIR"/compilation_database.json
+
+  if [ -n "$(find "$RESULTS_DIR"/compilation_databases -name "*.json")" ]
+  then
+    echo "Combining compilation databases into a single one ..."
+    echo "[" > "$CMDB"
+    find "$RESULTS_DIR"/compilation_databases -name "*.json" | \
+      sort -g | \
+      xargs cat | \
+      sed  '$ s:},$:}:g' >> "$CMDB"
+    echo "]" >> "$CMDB"
+  else
+    echo "Did not find JSON files to assemble a compilation database"
+  fi
 
   echo "found $(cat $REPLAYLOG | wc -l) calls to the compiler"
   [ ! -f "$REPLAYLOG" ] || echo "calls to replay can be found in: $REPLAYLOG"
   [ ! -f "$CALLLOG" ] || echo "more structured calls can be found in: $CALLLOG"
+  [ ! -f "$RESULTS_DIR/compilation_database.json" ] || echo "Combilation database can be found in: $CMDB"
   return 0
 }

--- a/configuration/backends/plain/plain-hook-install.sh
+++ b/configuration/backends/plain/plain-hook-install.sh
@@ -28,6 +28,13 @@ inject_plain()
   # use source dir to be able to copy the correct wrapper script
   local -r HOOK_SRC_DIR="$( dirname "${BASH_SOURCE[0]}" )"
 
+  local HAS_JQ=true
+  if ! command -v jq &> /dev/null
+  then
+    HAS_JQ=false
+    echo "warning: did not find jq, will not create compilation databases"
+  fi
+
   # install wrapper
   mkdir -p "$INSTALL_DIR"
   for SUFFIX in "" $TOOLSUFFIX
@@ -56,6 +63,12 @@ inject_plain()
 
     # tell the wrapper from where install has been called
     perl -p -i -e "s:CALL_DIR=:CALL_DIR=$(readlink -e $(pwd))/:" "$TARGET_GCC"
+
+    # in case we have jq present, we can create compilation databases
+    if [ "$HAS_JQ" = true ]
+    then
+      perl -p -i -e "s:HAS_JQ=false:HAS_JQ=true:" "$TARGET_GCC"
+    fi
 
     for t in gcc g++ clang clang++ as ld
     do


### PR DESCRIPTION
When compiling a project with one-line-scan, an interesting output
format is compilation databases, which can be consumed by other tools to
run further analysis on the target software. To make these databases
more accessible, dump this format when using the plain wrapper as well.

To keep track of dependencies in compilation, we add a nanosecond based
timestamp to each JSON blob that is created per compilation command.
When aggregating all JSON blobs, this time stamp is used to determine
the order.

Signed-off-by: Norbert Manthey <nmanthey@amazon.de>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Testing

I checked whether the created compilation database can be consume by infer's analysis on a toy project, and using a compiler that's not plain "g++". The below sequence results in the expected findings.

```
git clone https://github.com/conp-solutions/mergesat.git
cd mergesat
make clean -j 8; rm -rf INFER; time ~/projects/OneLineScan/one-line-scan --plain --no-gotocc -o INFER --suffix -7 --analysis-only --extra-cflags -fPIC -- make -j 8 CXX=g++-7
infer run --clang-compilation-db-files INFER/plain/compilation_database.json
```