### PR TITLE
One line cr bot

### DIFF
--- a/configuration/backends/AFL/AFL-hook-install.sh
+++ b/configuration/backends/AFL/AFL-hook-install.sh
@@ -80,7 +80,7 @@ inject_afl()
   perl -p -i -e "s:NATIVE_GPP=/bin/false:NATIVE_GPP=$(find_native g++):" "$TARGET_GCC"
   perl -p -i -e "s:NATIVE_CLANGPP=/bin/false:NATIVE_CLANGPP=$(find_native clang++):" "$TARGET_GCC"
 
-  for t in clang afl-clang g++ afl-g++ clang++ afl-clang++
+  for t in clang afl-clang g++ afl-g++ clang++ afl-clang++ ${OLS_TARGET_COMPILER:-}
   do
     cp "$TARGET_GCC" "$GOTO_GCC_WRAPPER_INSTALL_DIR/AFL/$t"
   done

--- a/configuration/backends/cbmc/gotocc-hook-install.sh
+++ b/configuration/backends/cbmc/gotocc-hook-install.sh
@@ -115,7 +115,7 @@ inject_gotocc()
     done
 
     # also use the wrapper for ld, ar, cc, c++
-    for t in ld ar cc c++
+    for t in ld ar cc c++ ${OLS_TARGET_COMPILER:-}
     do
       cp "$GOTO_GCC_WRAPPER_INSTALL_DIR/""$PREFIX"gcc"$SUFFIX" "$GOTO_GCC_WRAPPER_INSTALL_DIR/""$PREFIX"$t"$SUFFIX"
     done

--- a/configuration/backends/cppcheck/cppcheck-hook-install.sh
+++ b/configuration/backends/cppcheck/cppcheck-hook-install.sh
@@ -76,7 +76,7 @@ inject_cppcheck()
     done
 
     # make the other compiler use the fortify wrapper
-    for TARGET_COMPILER in g++ clang clang++ cc c++
+    for TARGET_COMPILER in g++ clang clang++ cc c++ ${OLS_TARGET_COMPILER:-}
     do
       # might fail, because if check-setup.sh is used, the directory is already
       # there, as well as the links

--- a/configuration/backends/cppcheck/cppcheck-wrapper.sh
+++ b/configuration/backends/cppcheck/cppcheck-wrapper.sh
@@ -25,14 +25,14 @@ NATIVE_CLANG=/bin/false
 NATIVE_CLANGPP=/bin/false
 TOOLPREFIX=
 TOOLSUFFIX=
-CPPCHECK_EXTRA_ARG=
+CPPCHECK_EXTRA_ARG="${CPPCHECK_EXTRA_ARG:-}"
 CALL_DIR=
 
 
 # options to be passed to cppcheck
-CHECK_CONFIG="--error-exitcode=-1 --quiet --force"
-CHECK_CONFIG+=" --enable=warning --enable=style --enable=performance"
-CHECK_CONFIG+=" --enable=information --enable=portability --inconclusive"
+CHECK_CONFIG="--error-exitcode=-1 --quiet --force --enable=warning"
+# CHECK_CONFIG+=" --enable=style --enable=performance"
+# CHECK_CONFIG+=" --enable=information --enable=portability --inconclusive"
 # CHECK_CONFIG+=" --check-config"  # enable to see problems with setup
 CHECK_CONFIG+="$CPPCHECK_EXTRA_ARG"
 

--- a/configuration/backends/fortify/fortify-hook-install.sh
+++ b/configuration/backends/fortify/fortify-hook-install.sh
@@ -75,7 +75,7 @@ inject_fortify()
     done
 
     # make the other compiler use the fortify wrapper
-    for TOOL in g++ clang clang++ cc c++
+    for TOOL in g++ clang clang++ cc c++ ${OLS_TARGET_COMPILER:-}
     do
       # might fail, because if check-setup.sh is used, the directory is already
       # there, as well as the links

--- a/configuration/backends/infer/infer-evaluate.sh
+++ b/configuration/backends/infer/infer-evaluate.sh
@@ -107,8 +107,10 @@ function evaluate_infer() {
   # run analysis on combined output from "infer capture --continue" calls
   echo "Running infer analyze (storing output in "$RESULTS_DIR"/infer_analyze.log) ..."
   local -i INFER_ANALYSIS_STATUS=0
+  INFER_ANALYSIS_EXTRA_ARGS="${INFER_ANALYSIS_EXTRA_ARGS:-}"
   infer analyze \
     --keep-going \
+    $INFER_ANALYSIS_EXTRA_ARGS \
     -o "$INFER_OUTPUT_DIR" &>"$RESULTS_DIR"/infer_analyze.log || INFER_ANALYSIS_STATUS=$?
 
   # for now, only use what is enabled by default!

--- a/configuration/backends/infer/infer-evaluate.sh
+++ b/configuration/backends/infer/infer-evaluate.sh
@@ -106,14 +106,21 @@ function evaluate_infer() {
 
   # run analysis on combined output from "infer capture --continue" calls
   echo "Running infer analyze (storing output in "$RESULTS_DIR"/infer_analyze.log) ..."
+  local -i INFER_ANALYSIS_STATUS=0
   infer analyze \
     --keep-going \
-    --bufferoverrun \
-    --litho \
-    --pulse \
-    --quandary \
-    --quandaryBO \
-    -o "$INFER_OUTPUT_DIR" &>"$RESULTS_DIR"/infer_analyze.log
+    -o "$INFER_OUTPUT_DIR" &>"$RESULTS_DIR"/infer_analyze.log || INFER_ANALYSIS_STATUS=$?
+
+  # for now, only use what is enabled by default!
+  #    --bufferoverrun \
+  #    --cost \
+  #    --pulse \
+  #    --quandary \
+
+  # Handle errors
+  if [ "$INFER_ANALYSIS_STATUS" -ne 0 ]; then
+    echo "There has been an error during analysis, please check: $RESULTS_DIR/infer_analyze.log"
+  fi
 
   # Other, potentially relevant, parameter to infer analyze:
   #     --purity \

--- a/configuration/backends/infer/infer-hook-install.sh
+++ b/configuration/backends/infer/infer-hook-install.sh
@@ -68,7 +68,7 @@ inject_infer() {
       done
 
       # make the other compiler use the fortify wrapper
-      for TARGET_COMPILER in g++ clang clang++ cc c++; do # as ld  # infer cannot do as and ld
+      for TARGET_COMPILER in g++ clang clang++ cc c++ ${OLS_TARGET_COMPILER:-}; do # as ld  # infer cannot do as and ld
         # might fail, because if check-setup.sh is used, the directory is already
         # there, as well as the links
         cp "$TARGET_GCC" "$INSTALL_DIR/${PREFIX}${TARGET_COMPILER}${SUFFIX}"

--- a/configuration/backends/plain/plain-evaluate.sh
+++ b/configuration/backends/plain/plain-evaluate.sh
@@ -21,7 +21,7 @@ function evaluate_plain
   local -r REPLAYLOG="$RESULTS_DIR/replay.log"
   local -r CMDB="$RESULTS_DIR"/compilation_database.json
 
-  if [ -n "$(find "$RESULTS_DIR"/compilation_databases -name "*.json")" ]
+  if [ -n "$(find "$RESULTS_DIR"/compilation_databases -name "*.json" 2> /dev/null)" ]
   then
     echo "Combining compilation databases into a single one ..."
     echo "[" > "$CMDB"

--- a/configuration/backends/plain/plain-hook-install.sh
+++ b/configuration/backends/plain/plain-hook-install.sh
@@ -78,7 +78,7 @@ inject_plain()
     done
 
     # make the other compiler use the fortify wrapper
-    for TARGET_COMPILER in g++ clang clang++ cc c++ as ld
+    for TARGET_COMPILER in g++ clang clang++ cc c++ as ld ${OLS_TARGET_COMPILER:-}
     do
       # might fail, because if check-setup.sh is used, the directory is already
       # there, as well as the links

--- a/configuration/backends/smatch/smatch-hook-install.sh
+++ b/configuration/backends/smatch/smatch-hook-install.sh
@@ -71,7 +71,7 @@ inject_smatch()
     done
 
     # make the other compiler use the fortify wrapper
-    for TARGET_COMPILER in g++ clang clang++ cc c++
+    for TARGET_COMPILER in g++ clang clang++ cc c++ ${OLS_TARGET_COMPILER:-}
     do
       # might fail, because if check-setup.sh is used, the directory is already
       # there, as well as the links

--- a/configuration/doc/EXAMPLES.md
+++ b/configuration/doc/EXAMPLES.md
@@ -60,3 +60,23 @@ x86_64-unknown-linux-gcc can be used, as well as other cross-compilers. To use
 such a compiler, the --prefix parameter can be added.
 
  one-line-scan --fortify --no-gotocc --prefix x86_64-unknown-linux- -- make
+
+## Infer Backend
+
+For some project setups, running Infer can be challenging, for example for
+projects that use cmake. Although cmake allows to dump a compilation database,
+in combination with non-gcc compilers, this setup is still challenging. This
+case is supported by one-line-scan as follows, assuming the additional compiler
+name is 'new-compiler'.
+
+As Infer calls are happening inside one-line-scan, it might be hard to add
+additional analysis options to Infer. The below environment variable
+INFER_ANALYSIS_EXTRA_ARGS can be used to forward analysis options.
+
+The following commands can be used to run Infer on a project with compiler
+'new-compiler', and with extra analysis options '--bufferoverrun'.
+
+  one-line-scan -o OLS --use-existing --no-gotocc --infer --no-analysis -- cmake
+  INFER_ANALYSIS_EXTRA_ARGS="--bufferoverrun" \
+      OLS_TARGET_COMPILER="my-compiler" \
+      one-line-scan -o OLS --use-existing --no-gotocc --inter -- make

--- a/configuration/doc/EXAMPLES.md
+++ b/configuration/doc/EXAMPLES.md
@@ -26,6 +26,17 @@ To store log files and results in another directory, the -o flag can be used:
 
  one-line-scan --no-analysis -o OLS -- make
 
+To add another run to the same output directory, depending on whether you want
+to keep the files from the previous run or not. To keep them, add the flag
+--use-existing, otherwise --trunc-existing. Example calls are as follows:
+
+ one-line-scan --no-analysis -o OLS -- gcc 1.c -o 1.o
+ one-line-scan --no-analysis -o OLS --use-existing -- gcc 2.c -o 2.o
+
+# Example Calls for Available Backends
+
+This section lists example calls for different backends.
+
 ## Plain Backend - Spot Failing Compiler Calls
 
 A use case of the plain backend is to trace failing compiler calls on a project

--- a/configuration/doc/README.md
+++ b/configuration/doc/README.md
@@ -140,7 +140,8 @@ space.
 Different backends currently support different mechanisms for customization.
 While CBMC and Fortify have CLI parameters for customization, Infer uses the
 environment variable INFER_ANALYSIS_EXTRA_ARGS to pass cli parameter to the
-Infer analysis call.
+Infer analysis call. For CppCheck, the environment variable CPPCHECK_EXTRA_ARG
+allows to add more CLI parameters to the tool.
 
 ## License
 

--- a/configuration/doc/README.md
+++ b/configuration/doc/README.md
@@ -5,7 +5,7 @@ static code analysis with tools like CBMC. One-line-scan hooks into the
 compilation process and wraps calls to the compiler with other compilers.
 Besides the compilation wrappers, one-line-scan ships with basic analysis jobs,
 that allow to analyze a project right after compilation with the following
-tools: AFL, cppcheck, CBMC, Fortify.
+tools: AFL, cppcheck, CBMC, Fortify, Infer.
 
 ## Usage
 
@@ -27,11 +27,121 @@ plain backend, which only tracks calls to the compiler, but does not act upon
 them. An example invocation for the plain backend and a project whose build
 command is "make" would be:
 
- one-line-scan --plain --no-gotocc -- make
+  one-line-scan --plain --no-gotocc -- make
 
-More invocations of one-line-scan are presented in the file
-configuration/doc/EXAMPLES.md
+The available parameters of the tool can be seen when using the --help flag:
+
+  one-line-scan --help
+
+More invocations of one-line-scan are presented in the file doc/EXAMPLES.md
+
+By default, the wrapper for CBMC is enabled. Furthermore, analysis is enabled by
+default. To disable CBMC, use --no-gotocc, and to disable analysis, use the
+parameter --no-analysis.
+
+## How It Works
+
+The tool one-line-scan places wrappers for common compilers like gcc, clang, as
+well as g++ and clang++ in a new directory. If the parameter --suffix $SUFFIX
+or --prefix $PREFIX is used, the wrapper is also created for binaries of the
+name ${PREFIX}compiler and compiler${SUFFIX}. This allows to also track compiler
+like gcc-9, or x86_64-unknown-linux-gnu-gcc.
+
+After all wrappers have been placed in the directory, the environment variable
+PATH is prepended with this directory. Hence, any attempt to spot the compiler
+via the PATH variable will result in picking up the wrapper, instead of the
+actual compiler. This allow us the take action on compiler invocations.
+
+To check which compiler would be visible inside the build command, run the
+following command that uses the plain wrapper:
+
+  one-line-scan --plain --no-gotocc -o OLS --trunc-existing -- which gcc
+
+With this mechanism, compiler calls based on their absolute path cannot be
+intercepted. Consequently, analysis will not detect these calls. To still be
+able to get these calls, one-line-scan should be used during the configuration
+with "./configure" or "cmake", and next should re-use the created directory for
+the actual compilation. This way, the wrapper will be used during configuration.
+See call examples in configuration/doc/EXAMPLES.md or more details below.
+
+## How to Use For
+
+### Different Build Systems
+
+This section explains the usage of one-line scan for the build systems using
+plain compilation, make, configure and make, as well as cmake, and give a brief
+example on what should be done.
+
+All example invocations will use a different analysis backend, to cover a few
+potential use cases. For each call, analysis will be enabled.
+
+#### Direct Compilation
+
+For a simple compiler invocation, specify the following line:
+
+  one-line-scan -o OLS --trunc-existing -- gcc test.c -o test
+
+#### Make
+
+Make typically uses compilers directly, without an absolute path -- depending on
+the actually used Makefile. Hence, the following command should be able to get
+the used compiler calls:
+
+  one-line-scan -o OLS --trunc-existing --no-gotocc --plain -- make
+
+#### Configure and Make
+
+Make typically uses compilers directly, without an absolute path. However, a
+preceeding configure call might set the absolute path based on the tools that
+have been detected. Hence, configuration and compilation should be run with the
+same one-line-scan directory. This directory should be re-used.
+
+  one-line-scan -o OLS --use-existing --no-gotocc --fortify --no-analysis -- ./configure
+  one-line-scan -o OLS --use-existing --no-gotocc --fortify -- make
+
+#### CMake
+
+Make typically uses compilers directly, without an absolute path. However, cmake
+typically spots used tools, and converts that into compiler names. To be able to
+intercept the compiler call, configuration and compilation should be run with
+the same one-line-scan directory. This directory should be re-used.
+
+  one-line-scan -o OLS --use-existing --no-gotocc --infer --no-analysis -- cmake
+  one-line-scan -o OLS --use-existing --no-gotocc --inter -- make
+
+In case cmake created a separate directory dir, use "make -C dir" to enter the
+directory "dir" for compilation.
+
+### Non-Standard Compiler Names
+
+There are compilers beyond gcc and clang++, e.g. clang++-9 or
+x86_64-unknown-linux-gnu-gcc. Wrapper for these compilers can be setup as well,
+by using the --prefix and --sufix parameter. The parameters can be combined.
+For the above compilers, example calls would be
+
+To wrap clang++-9, run:
+
+  one-line-scan -o OLS --suffix -9 -- make
+
+To wrap x86_64-unknown-linux-gnu-gcc, run:
+
+  one-line-scan -o OLS --prefix x86_64-unknown-linux-gnu- -- make
+
+To wrap x86_64-unknown-linux-gnu-gcc-8, run:
+
+    one-line-scan -o OLS --prefix x86_64-unknown-linux-gnu- --suffix -9 -- make
+
+The list of base compilers to be wrapped can be extended via the environment
+variable OLS_TARGET_COMPILER. If multiple should be added, separate them by a
+space.
+
+### Analysis Customization
+
+Different backends currently support different mechanisms for customization.
+While CBMC and Fortify have CLI parameters for customization, Infer uses the
+environment variable INFER_ANALYSIS_EXTRA_ARGS to pass cli parameter to the
+Infer analysis call.
 
 ## License
 
-This library is licensed under the Apache 2.0 License.
+This tool is licensed under the Apache 2.0 License.

--- a/configuration/inject-gcc-wrapper/setup.sh
+++ b/configuration/inject-gcc-wrapper/setup.sh
@@ -38,6 +38,10 @@
 #
 #        source remove-wrapper.sh
 #
+# environment variables:
+#
+#        add extra target compiler to be wrapped, split multiple with space: OLS_TARGET_COMPILER
+#
 # do not return with first non-zero exit of a prorgamm call, as this would terminate the calling shell
 # set -e
 

--- a/configuration/utils/extract_introduced_gcc_style.py
+++ b/configuration/utils/extract_introduced_gcc_style.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+#
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  or in the "license" file accompanying this file. This file is distributed
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#  express or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+from __future__ import print_function
+
+import logging
+import sys
+
+
+# setup logger for this module
+log = logging.getLogger(__name__)
+
+def usage(toolname="extract_introduced_gcc_style.py"):
+    print ("""usage: {} previous_msgs.txt current_msgs.txt
+
+  This script prints lines from the second input file that are not present in the first input file.
+  The files are assumed to be in gcc error style, i.e. when splitting each line into columns based
+  on the colon symbol ':', the first column is the file name, the second column is the line number,
+  and all remaining columns form the message. This script will ignore the line number for maching,
+  and instead just compare number of occurrences of messages per file, i.e. the comparison is done
+  on the remainder of the line.
+
+  As a result, all full lines from the second input file are printed, whose pattern without the line
+  information does not match the first input file often enough.
+
+  previous_msgs.txt ... text file of the form 'filename:linenumber: ...' for older msgs/warnings/...
+  current_msgs.txt .... text file of the form 'filename:linenumber: ...' for current msgs/warnings/...
+""".format(toolname))
+
+
+def drop_second_col(in_list):
+    """ Drop line info, convert into list """
+    ret = []
+    log.debug("Drop second col from %r", in_list)
+    for x in in_list:
+        y = x.split(":")
+        lineless = y[0:1] + y[2:]
+        log.debug("Add lineless list: %r", lineless)
+        ret.append(lineless)
+    return ret
+
+
+def main():
+
+    logging.basicConfig(
+        format="[%(levelname)-7s] %(asctime)s %(name)s %(message)s", level="WARNING",
+    )
+
+    # briefly check input
+    if len(sys.argv) != 3:
+        usage(sys.argv[0])
+        sys.exit(0)
+
+    # read files, fail early in case they cannot be found or opened
+    oldf = open(sys.argv[1])
+    newf = open(sys.argv[2])
+
+    # get the actual msg output, assume style to be correct
+    new_msgs = newf.readlines()
+    log.info("parsed %d new info", len(new_msgs))
+    old_msgs = oldf.readlines()
+    log.info("parsed %d old info", len(old_msgs))
+
+    # drop line in content
+    new_lineless = drop_second_col(new_msgs)
+    old_lineless = drop_second_col(old_msgs)
+    log.info("new lineless: %d", len(new_lineless))
+    log.info("old lineless: %d", len(old_lineless))
+
+    # calculate actual introduced msgs (could be done quicker using e.g. sets)
+    old_lineless_to_match = old_lineless[:]
+    introduced_lineless = []
+    for x in new_lineless:
+        if x in old_lineless_to_match:
+            old_lineless_to_match.remove(x)
+        else:
+            introduced_lineless.append(x)
+    log.info(
+        "introduced lineless: %d, left to match %d from %d",
+        len(introduced_lineless),
+        len(old_lineless_to_match),
+        len(old_lineless),
+    )
+
+    # get all candidates from new msgs that match above info, collect for all available line info
+    introduced_candidates = [
+        x for x in new_msgs if (x.split(":")[0:1] + x.split(":")[2:]) in introduced_lineless
+    ]
+    log.debug("introduced full candidates: %r", introduced_candidates)
+
+    # drop all candidates that appear in the old msgs with the same line number
+    introduced = []
+    old_msgs_to_match = old_msgs[:]
+    for x in introduced_candidates:
+        log.debug("Analyze %s", x)
+        if x in old_msgs_to_match:
+            old_msgs_to_match.remove(x)
+        else:
+            introduced.append(x.rstrip())
+    log.debug("Left %d from %d messages to match", len(old_msgs_to_match), len(old_msgs))
+
+    # present introduced msgs, each at most once
+    for msg in sorted(set(introduced)):
+        print (msg)
+
+    # indicate error in case we spotted new defects
+    return 0 if len(introduced) == 0 else 1
+
+
+if __name__ == "__main__":
+    # in case this module is the starting point, run the main function
+    ret = main()
+    log.debug("Exit main with %d", ret)
+    sys.exit(ret)

--- a/doc
+++ b/doc
@@ -1,0 +1,1 @@
+configuration/doc

--- a/one-line-cr-bot.sh
+++ b/one-line-cr-bot.sh
@@ -1,0 +1,531 @@
+#!/bin/bash
+#
+# Copyright (C) 2020 Amazon.com, Inc. or its affiliates.
+# Author: Norbert Manthey <nmanthey@amazon.de>
+#
+# Script to report errors/warnings/static code analysis output for a git commit series
+#
+# Tools currently used: infer, cppcheck
+# To potentially add: gcc-10 fanalyzer, cbmc
+#
+# If cppcheck or infer are not present in PATH, the tools can be obtained, and
+# build from their respective source in the www, all in a temporary folder that
+# will be thrown away after the invocation. If you plan to use this script
+# multiple time, consider installing these tools natively! To use this feature,
+# use the flag -I, or assign the value "true" to the environment variable
+# INSTALL_MISSING. Note, installation from the www might fail due to
+# unavailability.
+#
+# To customize the analysis of the used tools, check the documentation for the
+# backends of the one-line-scan tool. Configuration via environment variables is
+# possible.
+
+# Variables that can be influenced via environment, or CLI
+BASE_COMMIT="${BASE_COMMIT:-}"
+BUILD_COMMAND="${BUILD_COMMAND:-make -B}"
+CLEAN_COMMAND="${CLEAN_COMMAND:-make clean}"
+DEBUG="${DEBUG:-}"
+INFER_VERSION="${INFER_VERSION:-1.0.0}" # currently, we only support v1.0.0
+INGORE_ERRORS="${INGORE_ERRORS:-false}"
+INSTALL_MISSING="${INSTALL_MISSING:-false}"
+ONELINESCAN_PARAMS="${ONELINESCAN_PARAMS:-}"
+OUTPUT_FILE="${OUTPUT_FILE:-}"
+OVERRIDE_ANALYSIS_ERROR="${OVERRIDE_ANALYSIS_ERROR:-false}"
+REPORT_NEW_ONLY="${REPORT_NEW_ONLY:-false}"
+WORK_COMMIT="${WORK_COMMIT:-}"
+declare -i VERBOSE
+VERBOSE=${VERBOSE:-0}
+
+# Track tools to be run
+declare -a SUPPORTED_TOOLS=("infer" "cppcheck")
+declare -A RUN_TOOL
+RUN_TOOL["INFER"]="true"
+RUN_TOOL["CPPCHECK"]="true"
+
+#
+# DO NOT TOUCH THE BELOW
+#
+readonly PROG=$(basename "$0")
+readonly SCRIPT_DIR=$(readlink -f "$(dirname "$0")")
+readonly REPOSITORY_DIR=${PWD}
+
+TMP_DATA_FOLDER=""
+
+usage() {
+    cat <<EOF
+One-Line-CR Bot
+
+This script allows to run code analysis based on One-Line-Scan against a given
+code base, and eventually print the diff in defects wrt a base commit. The
+commands to be used, as well as the commits to be used for comparison, can be
+specified via environment or CLI parameters, where CLI will override the
+environment.
+
+Tools currently used: ${SUPPORTED_TOOLS[*]}
+
+If cppcheck or infer are not present in PATH, the tools can be obtained, and
+build from their respective source in the www, all in a temporary folder that
+will be thrown away after the invocation. If you plan to use this script
+multiple time, consider installing these tools natively! To use this feature,
+use the flag -I, or assign the value "true" to the environment variable
+INSTALL_MISSING. Note, installation from the www might fail due to
+unavailability.
+
+To customize the analysis of the used tools, check the documentation for the
+backends of the one-line-scan tool. Configuration via environment variables is
+possible.
+
+Some parameters can be set via environment variables. Those are named next to
+the default value for certain CLI parameters.
+
+  Usage:
+    $0 [options]
+
+  Options:
+
+  -b cmd ...... command used for building the project
+                (default: "$BUILD_COMMAND", env: BUILD_COMMAND)
+  -c cmd ...... command used for cleaning up the project
+                (default: "$CLEAN_COMMAND", env: CLEAN_COMMAND)
+
+  -B commit ... base commit to compare findings to
+                (default: "$BASE_COMMIT", env: BASE_COMMIT)
+  -W commit ... work commit to be used for current defect analysis
+                (default: "$WORK_COMMIT", env: WORK_COMMIT)
+
+  Enable tools, supported: ${SUPPORTED_TOOLS[*]}
+  -E TOOL ..... enable analysis with tool TOOL
+  -D TOOL ..... disable analysis with tool TOOL
+
+  -f .......... ignore errors during analysis of 1 commit
+                (default: $OVERRIDE_ANALYSIS_ERROR, env: OVERRIDE_ANALYSIS_ERROR)
+  -n .......... report only new findings, ignore moved lines
+                (default: $REPORT_NEW_ONLY, env: REPORT_NEW_ONLY)
+  -O args ..... extra command line options for one-line-scan invocations
+                (default: $ONELINESCAN_PARAMS, env: ONELINESCAN_PARAMS)
+  -y .......... ignore analysis errors
+                (default: $INGORE_ERRORS, env: INGORE_ERRORS)
+
+  -h .......... print this help message
+  -I .......... Try to install missing tools, if they cannot be found.
+                (default: $INSTALL_MISSING, env INSTALL_MISSING)
+  -d .......... print more information about the analysis invocation
+                (default: $DEBUG, env: DEBUG)
+  -o file ..... Text file where the introduced defects will be written to in gcc
+                error style.
+                (default: $OUTPUT_FILE, env: OUTPUT_FILE)
+  -v .......... be more verbose
+                (default: $VERBOSE, env: VERBOSE)
+EOF
+}
+
+cleanup_handler() {
+    local _PROG="$0"
+    local ERR="$1"
+    if [ "$ERR" != 0 ]; then
+        echo "$_PROG: cleanup_handler() invoked, exit status $ERR" 1>&2
+
+        # Print collected error output in case we failed
+        echo "Full stderr:"
+        [ -d "$TMP_DATA_FOLDER" ] && cat "$TMP_DATA_FOLDER"/stderr.log 2>/dev/null | awk '{print "stderr.log:" $0}'
+    fi
+
+    [ -d "$TMP_DATA_FOLDER" ] && rm -rf "$TMP_DATA_FOLDER"
+
+    # Try to get back to the initial commit as before (might result in head-less
+    # state). This is to not confuse interactive users of this script.
+    if [ -n "$WORK_COMMIT" ] && [ -n "$BASE_COMMIT" ]; then
+        pushd "$REPOSITORY_DIR" 1>&2
+        git checkout "$WORK_COMMIT" &>/dev/null
+        git submodule update --init --recursive &>/dev/null
+        popd 1>&2
+    fi
+
+    return "$ERR"
+}
+
+error_handler() {
+    local _PROG="$0"
+    local LINE="$1"
+    local ERR="$2"
+    if [ "$ERR" != 0 ]; then
+        echo "$_PROG: error_handler() invoked, line $LINE, exit status $ERR" 1>&2
+    fi
+
+    exit "$ERR"
+}
+
+trap 'error_handler ${LINENO} $?' ERR
+trap 'cleanup_handler $?' EXIT
+
+check_environment() {
+    local -i ret=0
+    # Print the version output of the available tools
+    echo "Versions of used tools:" 1>&2
+    for tool in "${SUPPORTED_TOOLS[@]}"; do
+        if ! command -v "$tool" &>/dev/null && [ "${RUN_TOOL["${tool^^}"]}" == "true" ]; then
+            echo "Error: Failed to find tool $tool, which has been activated. Abort" 1>&2
+            ret=1
+        else
+            $tool --version 1>&2 || true
+        fi
+    done
+
+    return $ret
+}
+
+setup_infer() {
+
+    local INSTALL_DIR="$1"
+    pushd "$INSTALL_DIR" 1>&2
+
+    echo "Setting up Infer..." 1>&2
+
+    # prepare for checking downloaded tar ball (taken from release web page)
+    echo "510eeccc7e6bcc2678ac92a88f8e1cb9c07c3e14d272dcc06834e93845bb120f  infer-linux64-v1.0.0.tar.xz" >infer-linux64-v1.0.0.tar.xz.sha256
+
+    # get infer with specified version, check and install
+    local -i ret=0
+    curl -sSL "https://github.com/facebook/infer/releases/download/v${INFER_VERSION}/infer-linux64-v${INFER_VERSION}.tar.xz" \
+        --output "infer-linux64-v${INFER_VERSION}.tar.xz" || ret=$?
+
+    # fail in case the download failed
+    if [ "$ret" -ne 0 ]; then
+        popd 1>&2
+        return 1
+    fi
+
+    # check obtained artefact, extract and make available in PATH
+    if ! shasum --status --algorithm 256 --check infer-linux64-v1.0.0.tar.xz.sha256; then
+        echo "Error: checksum of obtained infer version does not match"
+        popd 1>&2
+        return 1
+    fi
+
+    tar -xJf "infer-linux64-v${INFER_VERSION}.tar.xz" || ret=$?
+    export PATH=$PATH:"$(pwd)/infer-linux64-v${INFER_VERSION}/bin"
+
+    popd 1>&2
+
+    return "$ret"
+}
+
+setup_cppcheck() {
+
+    local -i ret=0
+    local INSTALL_DIR="$1"
+    pushd "$INSTALL_DIR" 1>&2
+
+    echo "Setting up CppCheck..." 1>&2
+
+    # get cppcheck source
+    git --depth 1 -b 2.2 https://github.com/danmar/cppcheck.git || ret=$?
+
+    # build cppcheck, print build output in case of failure
+    cd cppcheck
+    make -j "$(nproc)" &>build_cppcheck.log || ret=$?
+    [ "$ret" -ne 0 ] || cat build_cppcheck.log 1>&2 2>/dev/null
+
+    # make cppcheck available on PATH
+    export PATH=$PATH:"$(pwd)"
+
+    popd 1>&2
+
+    return $ret
+}
+
+setup_onelinescan() {
+    # use one-line-scan, which is also in our directory
+    export PATH="$SCRIPT_DIR":$PATH
+
+    command -v one-line-scan &>/dev/null || return 1
+    return 0
+}
+
+setup_environment() {
+    TMP_DATA_FOLDER="$(mktemp -d)"
+
+    if [ -z "$TMP_DATA_FOLDER" ]; then
+        echo "Error: failed to setup temporary directory, abort"
+        exit 1
+    fi
+
+    # In case no output file was specified, create one
+    [ -z "$OUTPUT_FILE" ] && OUTPUT_FILE="$TMP_DATA_FOLDER"/introduced-defects.txt
+
+    # Forward error output into stderr.log file, and do not print it unless we
+    # fail execution.
+    [ "$DEBUG" != "true" ] && exec 2>>"$TMP_DATA_FOLDER"/stderr.log
+
+    # Install tools, in case they are not present already
+    if [ "$INSTALL_MISSING" == "true" ]; then
+        if ! command -v infer &>/dev/null; then
+            setup_infer "$TMP_DATA_FOLDER" || return $?
+        fi
+
+        if ! command -v cppcheck &>/dev/null; then
+            setup_cppcheck "$TMP_DATA_FOLDER" || return $?
+        fi
+    fi
+
+    return 0
+}
+
+check_plain_build() {
+    # only show output of failed build
+    if ! $BUILD_COMMAND &>"$TMP_DATA_FOLDER"/plain_build.log; then
+        echo "Error: failed to build, log:"
+        cat "$TMP_DATA_FOLDER"/plain_build.log
+        return 1
+    fi
+
+    if ! $CLEAN_COMMAND &>"$TMP_DATA_FOLDER"/plain_clean.log; then
+        echo "Error: failed to clean, log:"
+        cat "$TMP_DATA_FOLDER"/plain_clean.log
+        return 2
+    fi
+    return 0
+}
+
+infer_analysis_findings() {
+    rm -rf "$TMP_DATA_FOLDER"/infer_files
+    local -i INFER_STATUS=0
+    one-line-scan -o "$TMP_DATA_FOLDER"/infer_files --trunc-existing --no-gotocc --infer $ONELINESCAN_PARAMS -- $BUILD_COMMAND &>"$TMP_DATA_FOLDER"/infer.log || INFER_STATUS=$?
+    cat "$TMP_DATA_FOLDER"/infer_files/infer/gcc_style_report.txt 2>/dev/null >>"$TMP_DATA_FOLDER"/findings.txt
+    $CLEAN_COMMAND &>/dev/null
+    return $INFER_STATUS
+}
+
+cppcheck_analysis_findings() {
+    rm -rf "$TMP_DATA_FOLDER"/cppcheck_files
+    local -i CPPCHECK_STATUS=0
+    one-line-scan -o "$TMP_DATA_FOLDER"/cppcheck_files --trunc-existing --no-gotocc --cppcheck $ONELINESCAN_PARAMS -- $BUILD_COMMAND &>"$TMP_DATA_FOLDER"/cppcheck.log || CPPCHECK_STATUS=$?
+    # forward findings, reduce noise for known noisy checkers
+    cat "$TMP_DATA_FOLDER"/cppcheck_files/cppcheck/results/* 2>/dev/null |
+        grep -v "^::" |
+        grep -v " (error:shiftTooManyBits) " |
+        grep -v " (error:integerOverflow) " |
+        sed "s:${PWD}/::g" \
+            >>"$TMP_DATA_FOLDER"/findings.txt
+    [ "$DEBUG" == "true" ] && cat "$TMP_DATA_FOLDER"/cppcheck_files/cppcheck/results/* | grep "^::" 1>&2 # present extra failures
+    $CLEAN_COMMAND &>/dev/null
+    return $CPPCHECK_STATUS
+}
+
+show_findings_for_series() {
+    [ ! -r "$TMP_DATA_FOLDER"/findings.txt ] && return 0
+    sort -u -V "$TMP_DATA_FOLDER"/findings.txt >"$TMP_DATA_FOLDER"/sorted-findings.txt 2>/dev/null
+
+    "$TMP_DATA_FOLDER"/one-line-scan/configuration/utils/display-series-data.sh "$TMP_DATA_FOLDER"/sorted-findings.txt "$BASE_COMMIT"
+}
+
+# analyze a project for a given commit
+analyze_project_commit() {
+    local COMMIT="${1:-}"
+
+    # handle slashes in commits properly
+    local COMMIT_FNAME=${COMMIT//\//_}
+
+    # if there is a commit to work with, look into this commit
+    if [ -n "$COMMIT" ]; then
+        git checkout "$COMMIT" &>/dev/null || exit $?
+        git submodule update --init --recursive &>/dev/null
+    fi
+
+    local -i BUILD_STATUS=0
+    check_plain_build || BUILD_STATUS=$?
+    if [ "$BUILD_STATUS" -ne 0 ]; then
+        echo "Failed to build and clean project, received exit code: $BUILD_STATUS" 1>&2
+        return $BUILD_STATUS
+    fi
+
+    local -i INFER_STATUS=0
+    if [ "${RUN_TOOL["INFER"]}" == "true" ]; then
+        infer_analysis_findings || INFER_STATUS=$?
+    else
+        echo "Configured to not run Infer" 1>&2
+    fi
+
+    local -i CPPCHECK_STATUS=0
+    if [ "${RUN_TOOL["CPPCHECK"]}" == "true" ]; then
+        cppcheck_analysis_findings || CPPCHECK_STATUS=$?
+    else
+        echo "Configured to not run CppCheck" 1>&2
+    fi
+
+    if [ "$INFER_STATUS" -ne 0 ]; then
+        echo "Failed infer analysis (on $COMMIT), received exit code: $INFER_STATUS" 1>&2
+        if [ "$DEBUG" == "true" ]; then
+            echo "Infer: output of failure" 1>&2
+            cat "$TMP_DATA_FOLDER"/infer.log 1>&2
+        fi
+    fi
+
+    if [ "$CPPCHECK_STATUS" -ne 0 ]; then
+        echo "Failed CppCheck analysis (on $COMMIT, might mean defects have been spotted), received exit code: $CPPCHECK_STATUS" 1>&2
+        if [ "$DEBUG" == "true" ]; then
+            echo "CppCheck: output of failure" 1>&2
+            cat "$TMP_DATA_FOLDER"/cppcheck.log 1>&2
+        fi
+    fi
+
+    # store findings for the current commit
+    touch "$TMP_DATA_FOLDER"/findings.txt
+    sort -u -V "$TMP_DATA_FOLDER"/findings.txt >"$TMP_DATA_FOLDER"/sorted-findings-"$COMMIT_FNAME".txt
+    mv "$TMP_DATA_FOLDER"/findings.txt "$TMP_DATA_FOLDER"/findings-"$COMMIT_FNAME".txt 2>/dev/null
+
+    mv "$TMP_DATA_FOLDER"/cppcheck_files "$TMP_DATA_FOLDER"/cppcheck_files-"$COMMIT_FNAME" 2>/dev/null
+    mv "$TMP_DATA_FOLDER"/infer_files "$TMP_DATA_FOLDER"/infer_files-"$COMMIT_FNAME" 2>/dev/null
+
+    [ "$INFER_STATUS" -ne 0 ] && return 1
+    [ "$CPPCHECK_STATUS" -ne 0 ] && return 1
+    return 0
+}
+
+# Use current commit as work commit, if no other commit is specified
+if [ -z "$WORK_COMMIT" ]; then
+    # Try to use a symbolic name, fall back to plain commit ID
+    WORK_COMMIT=$(git rev-parse --symbolic-full-name HEAD | sed 's:^refs/heads/::g')
+    [ -z "$WORK_COMMIT" -o "$WORK_COMMIT" == "HEAD" ] && WORK_COMMIT=$(git rev-parse HEAD)
+fi
+
+while getopts "0b:B:c:dD:E:fhIno:O:vW:y" opt; do
+    case $opt in
+    b)
+        BUILD_COMMAND="$OPTARG"
+        ;;
+    B)
+        BASE_COMMIT="$OPTARG"
+        ;;
+    c)
+        CLEAN_COMMAND="$OPTARG"
+        ;;
+    d)
+        DEBUG="true"
+        ;;
+    D)
+        if [[ ! " ${SUPPORTED_TOOLS[*]^^} " =~ " ${OPTARG^^} " ]]; then
+            echo "Error: unknown tool to disable ${OPTARG} (supported: ${SUPPORTED_TOOLS[*]})"
+            exit 1
+        fi
+        RUN_TOOL["${OPTARG^^}"]="false"
+        ;;
+    E)
+        if [[ ! " ${SUPPORTED_TOOLS[*]^^} " =~ " ${OPTARG^^} " ]]; then
+            echo "Error: unknown tool to enable ${OPTARG} (supported: ${SUPPORTED_TOOLS[*]})"
+            exit 1
+        fi
+        RUN_TOOL["${OPTARG^^}"]="true"
+        ;;
+    f)
+        OVERRIDE_ANALYSIS_ERROR="true"
+        ;;
+    I)
+        INSTALL_MISSING="true"
+        ;;
+    n)
+        REPORT_NEW_ONLY="true"
+        ;;
+    h)
+        usage
+        exit 0
+        ;;
+    o)
+        OUTPUT_FILE="$OPTARG"
+        ;;
+    O)
+        ONELINESCAN_PARAMS="$OPTARG"
+        ;;
+    W)
+        WORK_COMMIT="$OPTARG"
+        ;;
+    v)
+        VERBOSE=$((VERBOSE + 1))
+        ;;
+    y)
+        INGORE_ERRORS="true"
+        ;;
+    :)
+        echo "Option -$OPTARG requires an argument." >&2
+        echo ""
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+if [ "$DEBUG" == "true" ]; then
+    echo "Tool Environment:" 1>&2
+    env | sort -V 1>&2
+fi
+
+setup_environment 1>&2 || exit 1
+setup_onelinescan 1>&2 || exit 2
+check_environment 1>&2 || exit 3
+
+# make sure we handle slashes in commit names for files
+BASE_COMMIT_FNAME=${BASE_COMMIT//\//_}
+WORK_COMMIT_FNAME=${WORK_COMMIT//\//_}
+
+# analyze series, if presented, or just analyze current state
+declare -i DEFECT_STATUS=0
+declare -i OVERALL_STATUS=0
+if [ -n "$BASE_COMMIT" ]; then
+    echo "Run diff analysis with given base commit $BASE_COMMIT ($(git rev-parse "$BASE_COMMIT"))"
+    if [ "$(git rev-parse "$BASE_COMMIT")" == "$(git rev-parse "$WORK_COMMIT")" ]; then
+        echo "Reject diff analysis, due to using same commit."
+    else
+        analyze_project_commit "$BASE_COMMIT" || OVERALL_STATUS=$?
+        analyze_project_commit "$WORK_COMMIT" || OVERALL_STATUS=$?
+
+        BASE_FINDINGS=$(cat "$TMP_DATA_FOLDER"/sorted-findings-"$BASE_COMMIT_FNAME".txt | sort -u | wc -l)
+        TIP_FINDINGS=$(cat "$TMP_DATA_FOLDER"/sorted-findings-"$WORK_COMMIT_FNAME".txt | sort -u | wc -l)
+        echo "Spotted $BASE_FINDINGS findings for base, and $TIP_FINDINGS for current commit"
+
+        if [ -r "$TMP_DATA_FOLDER"/sorted-findings-"$BASE_COMMIT_FNAME".txt ] &&
+            [ -r "$TMP_DATA_FOLDER"/sorted-findings-"$BASE_COMMIT_FNAME".txt ]; then
+            echo -e "\n\nAll findings worth reporting as introduced:"
+            if [ "$REPORT_NEW_ONLY" == "true" ]; then
+                "$SCRIPT_DIR"/configuration/utils/extract_introduced_gcc_style.py \
+                    "$TMP_DATA_FOLDER"/sorted-findings-"$BASE_COMMIT_FNAME".txt \
+                    "$TMP_DATA_FOLDER"/sorted-findings-"$WORK_COMMIT_FNAME".txt | tee -a "$OUTPUT_FILE"
+                DEFECT_STATUS="${PIPESTATUS[0]}"
+            else
+                diff --new-line-format="" --unchanged-line-format="" \
+                    "$TMP_DATA_FOLDER"/sorted-findings-"$WORK_COMMIT_FNAME".txt \
+                    "$TMP_DATA_FOLDER"/sorted-findings-"$BASE_COMMIT_FNAME".txt | tee -a "$OUTPUT_FILE"
+                DEFECT_STATUS="${PIPESTATUS[0]}"
+            fi
+            echo -e "\n\n"
+
+            [ "$DEFECT_STATUS" -eq 0 ] && echo "Did not detect relevant findings"
+            [ "$OVERRIDE_ANALYSIS_ERROR" == "true" ] && OVERALL_STATUS=0
+        else
+            echo "Error: Did not find comparison files for both commits, abort"
+            OVERALL_STATUS=1
+        fi
+
+        if [ "$VERBOSE" -gt 0 ]; then
+            SHOW_WORK_COMMIT=$(git rev-parse $WORK_COMMIT)
+            [ "$SHOW_WORK_COMMIT" != "$WORK_COMMIT" ] && SHOW_WORK_COMMIT="$WORK_COMMIT ($SHOW_WORK_COMMIT)"
+            echo -e "\n\nAll findings in current work commit ($SHOW_WORK_COMMIT):"
+            sort -uV "$TMP_DATA_FOLDER"/sorted-findings-"$WORK_COMMIT_FNAME".txt
+            echo -e "\n\n"
+        fi
+    fi
+else
+    echo "Did not spot a base commit, run plain analysis ..."
+    TARGET_COMMIT=""
+    analyze_project_commit "$TARGET_COMMIT" || DEFECT_STATUS=$?
+    cat "$TMP_DATA_FOLDER"/sorted-findings-"$TARGET_COMMIT".txt
+fi
+
+# ignore errors, if requested
+[ "$INGORE_ERRORS" == "true" ] && exit 0
+
+# All steps we ran worked, signal success
+if [ "$DEFECT_STATUS" -eq 0 ]; then
+    exit $OVERALL_STATUS
+fi
+exit $DEFECT_STATUS


### PR DESCRIPTION
*Issue #, if available:*

This series fixes the invocation of Infer, to allow using Infer v1.0.0. Furthermore, Infer and CppCheck analysis can be controlled via environment variables.

The documentation of the tool is improved as well, including describing how it works, providing examples and explaining environment variables.

The one-line-cr-bot.sh script is added to the repository as well, which allows to analyze a git commit series and presents the set of introduced defects. See e.g. https://github.com/nmanthey/ktf/runs/1271790410?check_suite_focus=true for testing done as part of a github workflow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
