### PR TITLE
docker: add a minimum dockerfile

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:20.04
+
+ARG INFER_VERSION=v1.0.0
+
+# build dependencies
+RUN apt-get update -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install cppcheck git curl xz-utils
+
+# install one-line-scan
+RUN git clone https://github.com/awslabs/one-line-scan.git /opt/one-line-scan
+
+# install infer
+RUN curl -o /tmp/infer.tar.xz -sSL "https://github.com/facebook/infer/releases/download/${INFER_VERSION}/infer-linux64-${INFER_VERSION}.tar.xz"
+RUN tar -C /opt -xJf /tmp/infer.tar.xz
+RUN ln -s "/opt/infer-linux64-${INFER_VERSION}/bin/infer" /usr/local/bin/infer
+
+CMD ["/opt/one-line-scan/one-line-cr-bot.sh", "-E", "infer", "-E", "cppcheck"]


### PR DESCRIPTION
This adds a Dockerfile which can be used as a base image in other projects to
support one-line-scan in a docker container.

Signed-off-by: Martin Mazein <amazein@amazon.de>

*Issue #, if available:*

*Description of changes:*

Adding a minimal dockerfile for inclusion in other projects.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
