### PR TITLE
one-line-cr-bot: show errors for git commands

### DIFF
--- a/one-line-cr-bot.sh
+++ b/one-line-cr-bot.sh
@@ -348,8 +348,8 @@ analyze_project_commit() {
 
     # if there is a commit to work with, look into this commit
     if [ -n "$COMMIT" ]; then
-        git checkout "$COMMIT" &>/dev/null || exit $?
-        git submodule update --init --recursive &>/dev/null
+        git checkout -q "$COMMIT" || exit $?
+        git submodule --quiet update --init --recursive
     fi
 
     local -i BUILD_STATUS=0


### PR DESCRIPTION
Instead of throwing every output away, show errors during git execution for
easier debugging.

Signed-off-by: Martin Mazein <amazein@amazon.de>

*Description of changes:*

Be verbose about errors executing git commands. This helps during debugging of issues.

E.g. instead of having zero output during execution of local onelinescan in another project, I now get the information that the execution would overwrite my data and that I have to commit my data before running one-line-scan:

```
BEFORE

$ make onelinescan
scanning current working directory with one-line-scan
Run diff analysis with given base commit mainline (9b390ef4d4f042f66a1cefcedf84137b7c746678)
Full stderr:
stderr.log:Versions of used tools:
stderr.log:Infer version v1.0.0
stderr.log:Copyright 2009 - present Facebook. All Rights Reserved.
stderr.log:Cppcheck 1.90
stderr.log:/opt/one-line-scan/one-line-cr-bot.sh: cleanup_handler() invoked, exit status 1
make: *** [onelinescan] Error 1

AFTER

$ make onelinescan
scanning current working directory with one-line-scan
Run diff analysis with given base commit origin/mainline (9c6df2ea89a4fa086430dabed4379f6f8a3c6008)
Full stderr:
stderr.log:Versions of used tools:
stderr.log:Infer version v1.0.0
stderr.log:Copyright 2009 - present Facebook. All Rights Reserved.
stderr.log:Cppcheck 1.90
stderr.log:error: Your local changes to the following files would be overwritten by checkout:
stderr.log:     tools/docker/OnelineScanDockerfile
stderr.log:Please commit your changes or stash them before you switch branches.
stderr.log:Aborting
stderr.log:/opt/one-line-scan/one-line-cr-bot.sh: cleanup_handler() invoked, exit status 1
make: *** [onelinescan] Error 1
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
