### PR TITLE
cr-bot: use pull_request

### DIFF
--- a/doc/ONELINECRBOT.md
+++ b/doc/ONELINECRBOT.md
@@ -34,8 +34,10 @@ pull_request_target, which has permissions to add comments.
     # script 'one-line-cr-bot.sh' in https://github.com/awslabs/one-line-scan.git
     name: One Line CR Bot
 
+    # Using pull_request_target poses a security risk, as the token could be
+    # leaked. Hence, you should not use the comment on PR functionality.
     on:
-    pull_request_target:
+    pull_request:
       # [ACTION REQUIRED] Set the branch you want to analyze PRs for
       branches:
         - '**'
@@ -97,7 +99,8 @@ pull_request_target, which has permissions to add comments.
             IGNORE_ERRORS: false
             INSTALL_MISSING: true
             OVERRIDE_ANALYSIS_ERROR: true
-            POST_TO_GITHUB_PR_ONLY: true
+            POST_TO_GITHUB_PR: false
+            POST_TO_GITHUB_PR_ONLY: false
             REPORT_NEW_ONLY: true
             VERBOSE: 0 # >0 shows all currently present defects as well
         # Be explicit about the tools to be used


### PR DESCRIPTION
The bot that consumes code changes and analyzes them should not have
access to a GITHUB TOKEN that provides write access. Otherwise, info
about this token could be leaked via some channel.

Hence, do recomment to NOT use this feature for now.

A workaround is a split model where the currentl action writes the
reported defects as artifacts, and has access to the read-only GITHUB
TOKEN. Next, another scheduled workflow of the upstream repository will
check for new PRs and their artifacts, and will post them to the PRs as
comment. The second workflow is static, and owned by the upstream
repository, so a PR cannot leak the secret GITHUB TOKEN.

Signed-off-by: Norbert Manthey <nmanthey@amazon.de>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
