### PR TITLE
cppcheck: do not report version

### DIFF
--- a/backends/cppcheck/cppcheck-hook-install.sh
+++ b/backends/cppcheck/cppcheck-hook-install.sh
@@ -35,13 +35,6 @@ inject_cppcheck()
     return 1
   fi
 
-  # check the cppcheck version, and warn if there is a more recent version (at the time of writing)
-  CPPCHECK_VERSION=$(cppcheck --version | cut -d ' ' -f 2)
-  if (( $(echo "$CPPCHECK_VERSION < 1.81" |bc -l) ))
-  then
-    log "Note: there is a more recent cppcheck version, visit http://cppcheck.sourceforge.net/!"
-  fi
-
   # install wrapper
   mkdir -p "$INSTALL_DIR"
   for SUFFIX in "" $TOOLSUFFIX


### PR DESCRIPTION
One-line-scan is not the right tool to check running versions of
available analysis tools. Hence, drop the version comparison and
warning.

This also allows to drop the dependency on the 'bc' tool.

Signed-off-by: Norbert Manthey <nmanthey@amazon.de>