### PR TITLE
Fix logging interference in rewriteToNonexisting

### DIFF
--- a/one-line-scan
+++ b/one-line-scan
@@ -75,7 +75,7 @@ rewriteToNonexisting ()
 		TRY=$(($TRY+1))
 		FINALDIR="$STARTDIR$TRY"
 	done
-	log "$FINALDIR"
+	echo "$FINALDIR"
 }
 
 # store environment when building with one-line-scan


### PR DESCRIPTION
The string returned by rewriteToNonexisting must not be subject to log's
transformations: doing so resulted in output directories that included a
timestamp and whitespace, which in turn confused several later passes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
